### PR TITLE
🧪 Add testing for invalid relativeDataDir error handling in detect.ts

### DIFF
--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -139,6 +139,39 @@ describe("matchCurrentUserdata", () => {
 
     assert.equal(match.kind, "unmanaged");
   });
+
+  it("skips invalid managed userdata and continues to the next item", () => {
+    const validEntry = {
+      id: "valid",
+      kind: "managed" as const,
+      label: "Valid",
+      relativeDataDir: "u/valid",
+    };
+    const invalidRegistry: Registry = {
+      version: 1,
+      userdatas: [
+        {
+          id: "invalid",
+          kind: "managed",
+          label: "Invalid",
+          relativeDataDir: "../invalid",
+        },
+        validEntry,
+      ],
+    };
+
+    const match = matchCurrentUserdata({
+      globalStoragePath: globalStoragePath(path.join(STORE_ROOT, "u", "valid")),
+      defaultUserdataRoot: DEFAULT_ROOT,
+      storeRoot: STORE_ROOT,
+      registry: invalidRegistry,
+    });
+
+    assert.deepEqual(match, {
+      kind: "known",
+      entry: validEntry,
+    });
+  });
 });
 
 describe("resolveCurrentUserdataRoot", () => {


### PR DESCRIPTION
🎯 **What:** Addressed an untested error handling case in `detect.ts` where `resolveManagedDataDir` could throw an error on malformed paths but had no test asserting that it successfully continues to the next item.
📊 **Coverage:** Now explicitly tests that `matchCurrentUserdata` handles and ignores invalid `relativeDataDir` fields that throw errors by continuing its loop and correctly returning a valid entry later in the array.
✨ **Result:** Enhanced test coverage and increased confidence that invalid paths do not crash userdata detection.

---
*PR created automatically by Jules for task [13240880158620414549](https://jules.google.com/task/13240880158620414549) started by @domoarigatomrburato*