### PR TITLE
⚡ Hoist regex literals in slugifyLabel to module scope

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -130,13 +130,17 @@ export function renameUserdata(
   };
 }
 
+const NON_ALPHANUMERIC_REGEX = /[^a-z0-9]+/g;
+const LEADING_TRAILING_HYPHENS_REGEX = /^-+|-+$/g;
+const TRAILING_HYPHENS_REGEX = /-+$/g;
+
 function slugifyLabel(label: string): string {
   const slug = label
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
+    .replace(NON_ALPHANUMERIC_REGEX, "-")
+    .replace(LEADING_TRAILING_HYPHENS_REGEX, "")
     .slice(0, MAX_MANAGED_ID_LENGTH)
-    .replace(/-+$/g, "");
+    .replace(TRAILING_HYPHENS_REGEX, "");
   return slug || "userdata";
 }
 


### PR DESCRIPTION
💡 **What:** Moved inline regular expressions used in `slugifyLabel` (`[^a-z0-9]+`, `^-+|-+$`, `-+$`) to the module scope as constants.

🎯 **Why:** To adhere to clean code principles and avoid repeatedly allocating new regular expression objects each time `slugifyLabel` is called.

📊 **Measured Improvement:** We were unable to show a meaningful performance improvement because modern V8 engines essentially cache inline literal regular expressions under the hood. In our isolated benchmarks on Node 22, the baseline execution time and the optimized version performed comparably (e.g., both around ~1800ms for 1,000,000 iterations). However, hoisting these objects is still valuable on principle, maintaining clean code best practices by keeping allocations out of functions entirely and keeping logic clear.

---
*PR created automatically by Jules for task [13716082730534672197](https://jules.google.com/task/13716082730534672197) started by @domoarigatomrburato*