### PR TITLE
feat: add support for Antigravity IDE

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,8 +7,8 @@ supported editor with named, isolated userdata roots.
 
 **Editor Host**:
 A supported VS Code-family desktop application that can run this extension and
-be launched with a userdata root, such as Cursor, Visual Studio Code, or Visual
-Studio Code Insiders.
+be launched with a userdata root, such as Cursor, Visual Studio Code, Visual
+Studio Code Insiders, or Antigravity IDE.
 _Avoid_: arbitrary fork, guessed host
 
 **Editor Userdata**:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ when you need isolation beyond that.
 - Cursor
 - Visual Studio Code
 - Visual Studio Code Insiders
+- Antigravity IDE
 
 Unsupported VS Code-family forks are not guessed automatically. This extension
 runs in the **local desktop UI** and does not activate in Remote SSH, WSL, dev

--- a/docs/adr/0001-use-supported-editor-userdata-roots.md
+++ b/docs/adr/0001-use-supported-editor-userdata-roots.md
@@ -26,6 +26,7 @@ The initial supported hosts are:
 - Cursor
 - Visual Studio Code
 - Visual Studio Code Insiders
+- Antigravity IDE
 
 Unsupported hosts are not guessed. The extension reports a clear unsupported
 host error instead of falling back to best-effort behavior.

--- a/src/host.test.ts
+++ b/src/host.test.ts
@@ -190,6 +190,17 @@ describe("resolveDefaultUserdataRoot", () => {
     );
   });
 
+  it("resolves the macOS default Antigravity IDE userdata root", () => {
+    assert.equal(
+      antigravityIde.resolveDefaultUserdataRoot({
+        platform: "darwin",
+        home: "/Users/alice",
+        env: {},
+      }),
+      "/Users/alice/Library/Application Support/Antigravity IDE",
+    );
+  });
+
   it("resolves the Linux default Antigravity IDE userdata root", () => {
     assert.equal(
       antigravityIde.resolveDefaultUserdataRoot({
@@ -198,6 +209,17 @@ describe("resolveDefaultUserdataRoot", () => {
         env: {},
       }),
       "/home/alice/.config/Antigravity IDE",
+    );
+  });
+
+  it("resolves the Windows default Antigravity IDE userdata root", () => {
+    assert.equal(
+      antigravityIde.resolveDefaultUserdataRoot({
+        platform: "win32",
+        home: "C:\\Users\\alice",
+        env: {},
+      }),
+      "C:\\Users\\alice\\AppData\\Roaming\\Antigravity IDE",
     );
   });
 });
@@ -236,6 +258,17 @@ describe("resolveSharedExtensionsDirectory", () => {
     );
   });
 
+  it("resolves the macOS Antigravity IDE shared extensions directory", () => {
+    assert.equal(
+      antigravityIde.resolveSharedExtensionsDirectory({
+        platform: "darwin",
+        home: "/Users/alice",
+        env: {},
+      }),
+      "/Users/alice/.antigravity-ide/extensions",
+    );
+  });
+
   it("resolves the Linux Antigravity IDE shared extensions directory", () => {
     assert.equal(
       antigravityIde.resolveSharedExtensionsDirectory({
@@ -244,6 +277,17 @@ describe("resolveSharedExtensionsDirectory", () => {
         env: {},
       }),
       "/home/alice/.antigravity-ide/extensions",
+    );
+  });
+
+  it("resolves the Windows Antigravity IDE shared extensions directory", () => {
+    assert.equal(
+      antigravityIde.resolveSharedExtensionsDirectory({
+        platform: "win32",
+        home: "C:\\Users\\alice",
+        env: {},
+      }),
+      "C:\\Users\\alice\\.antigravity-ide\\extensions",
     );
   });
 });

--- a/src/host.test.ts
+++ b/src/host.test.ts
@@ -11,9 +11,14 @@ const insiders = resolveEditorHost({
   appName: "Visual Studio Code - Insiders",
   uriScheme: "vscode-insiders",
 });
+const antigravityIde = resolveEditorHost({
+  appName: "Antigravity IDE",
+  uriScheme: "antigravity-ide",
+});
 assert.ok(cursor);
 assert.ok(vscode);
 assert.ok(insiders);
+assert.ok(antigravityIde);
 
 describe("resolveEditorHost", () => {
   it("resolves Cursor from the URI scheme", () => {
@@ -47,6 +52,17 @@ describe("resolveEditorHost", () => {
     assert.equal(host?.id, "vscode-insiders");
     assert.equal(host?.displayName, "Visual Studio Code - Insiders");
     assert.deepEqual(host?.cliNames, ["code-insiders"]);
+  });
+
+  it("resolves Antigravity IDE from the URI scheme", () => {
+    const host = resolveEditorHost({
+      appName: "Antigravity IDE",
+      uriScheme: "antigravity-ide",
+    });
+
+    assert.equal(host?.id, "antigravity-ide");
+    assert.equal(host?.displayName, "Antigravity IDE");
+    assert.deepEqual(host?.cliNames, ["antigravity-ide"]);
   });
 
   it("does not guess unsupported hosts", () => {
@@ -91,6 +107,39 @@ describe("resolveStoreRoot", () => {
         env: {},
       }),
       "C:\\Users\\alice\\AppData\\Local\\udsw\\vscode-insiders",
+    );
+  });
+
+  it("resolves the macOS store root under a host namespace for Antigravity IDE", () => {
+    assert.equal(
+      antigravityIde.resolveStoreRoot({
+        platform: "darwin",
+        home: "/Users/alice",
+        env: {},
+      }),
+      "/Users/alice/Library/Application Support/udsw/antigravity-ide",
+    );
+  });
+
+  it("resolves the Linux store root under a host namespace for Antigravity IDE", () => {
+    assert.equal(
+      antigravityIde.resolveStoreRoot({
+        platform: "linux",
+        home: "/home/alice",
+        env: {},
+      }),
+      "/home/alice/.local/share/udsw/antigravity-ide",
+    );
+  });
+
+  it("resolves the Windows store root under a host namespace for Antigravity IDE", () => {
+    assert.equal(
+      antigravityIde.resolveStoreRoot({
+        platform: "win32",
+        home: "C:\\Users\\alice",
+        env: {},
+      }),
+      "C:\\Users\\alice\\AppData\\Local\\udsw\\antigravity-ide",
     );
   });
 
@@ -140,6 +189,17 @@ describe("resolveDefaultUserdataRoot", () => {
       "C:\\Users\\alice\\AppData\\Roaming\\Code - Insiders",
     );
   });
+
+  it("resolves the Linux default Antigravity IDE userdata root", () => {
+    assert.equal(
+      antigravityIde.resolveDefaultUserdataRoot({
+        platform: "linux",
+        home: "/home/alice",
+        env: {},
+      }),
+      "/home/alice/.config/Antigravity IDE",
+    );
+  });
 });
 
 describe("resolveSharedExtensionsDirectory", () => {
@@ -175,6 +235,17 @@ describe("resolveSharedExtensionsDirectory", () => {
       "C:\\Users\\alice\\.vscode-insiders\\extensions",
     );
   });
+
+  it("resolves the Linux Antigravity IDE shared extensions directory", () => {
+    assert.equal(
+      antigravityIde.resolveSharedExtensionsDirectory({
+        platform: "linux",
+        home: "/home/alice",
+        env: {},
+      }),
+      "/home/alice/.antigravity-ide/extensions",
+    );
+  });
 });
 
 describe("discoverEditorCli bundled discovery", () => {
@@ -203,6 +274,22 @@ describe("discoverEditorCli bundled discovery", () => {
         },
       ),
       "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+    );
+  });
+
+  it("finds the bundled Antigravity IDE CLI under appRoot on Linux", () => {
+    assert.equal(
+      antigravityIde.discoverEditorCli(
+        "/opt/antigravity-ide/Antigravity-IDE/resources/app",
+        {
+          env: { PATH: "/usr/local/bin" },
+          existsSync: (candidate) =>
+            candidate ===
+            "/opt/antigravity-ide/Antigravity-IDE/resources/app/bin/antigravity-ide",
+          platform: "linux",
+        },
+      ),
+      "/opt/antigravity-ide/Antigravity-IDE/resources/app/bin/antigravity-ide",
     );
   });
 

--- a/src/host.ts
+++ b/src/host.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-type EditorHostId = "cursor" | "vscode" | "vscode-insiders";
+type EditorHostId = "cursor" | "vscode" | "vscode-insiders" | "antigravity-ide";
 
 export interface EditorHostIdentity {
   appName: string;
@@ -75,6 +75,15 @@ const HOST_DEFINITIONS: HostDefinition[] = [
     sharedExtensionsRelativePath: ".vscode-insiders/extensions",
     cliNames: ["code-insiders"],
     windowsExecutableNames: ["Code - Insiders.exe"],
+  },
+  {
+    id: "antigravity-ide",
+    displayName: "Antigravity IDE",
+    storageSlug: "antigravity-ide",
+    defaultUserdataDirName: "Antigravity IDE",
+    sharedExtensionsRelativePath: ".antigravity-ide/extensions",
+    cliNames: ["antigravity-ide"],
+    windowsExecutableNames: ["Antigravity IDE.exe", "antigravity-ide.exe"],
   },
 ];
 


### PR DESCRIPTION
This PR adds support for the **Antigravity IDE** editor alongside the existing supported editors (Cursor, VS Code, VS Code Insiders) in the Userdata Switcher extension.

### Changes Included:
- **`src/host.ts`**: Added support config for Antigravity IDE to allow launching with user data directories.
- **`src/host.test.ts`**: Added cross-platform test cases checking host path resolution and CLI detection.
- **Documentation**: Updated `README.md` and the ADR `docs/adr/0001-use-supported-editor-userdata-roots.md` to document Antigravity IDE as a supported host.

All local static checks and tests run successfully.
