### PR TITLE
feat: implement managed userdata deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ when you need isolation beyond that.
 - Cursor
 - Visual Studio Code
 - Visual Studio Code Insiders
+- Antigravity IDE
 
 Unsupported VS Code-family forks are not guessed automatically. This extension
 runs in the **local desktop UI** and does not activate in Remote SSH, WSL, dev

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Switcher**.
 
 ![Open With Userdata menu](media/screenshot-menu.png)
 
+## Deleting a Userdata
+
+If you no longer need a managed userdata, you can delete it:
+1. Click the status bar item or run `Userdata Switcher: Open With Userdata`.
+2. Choose `Delete Userdata...` (or run `Userdata Switcher: Delete Userdata` directly from the Command Palette).
+3. Select the userdata you want to delete.
+4. Confirm the prompt to move its files to your system's Trash/Recycle Bin and remove it from the registry.
+
+You cannot delete the userdata of the currently active window, or the default editor userdata.
+
 ## What Stays Separate
 
 - **Isolated:** accounts, subscriptions, sessions, chat history, caches, tabs,

--- a/docs/adr/0001-use-supported-editor-userdata-roots.md
+++ b/docs/adr/0001-use-supported-editor-userdata-roots.md
@@ -26,6 +26,7 @@ The initial supported hosts are:
 - Cursor
 - Visual Studio Code
 - Visual Studio Code Insiders
+- Antigravity IDE
 
 Unsupported hosts are not guessed. The extension reports a clear unsupported
 host error instead of falling back to best-effort behavior.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
         "command": "userdataSwitcher.revealCurrentUserdata",
         "title": "Reveal Current Userdata",
         "category": "Userdata Switcher"
+      },
+      {
+        "command": "userdataSwitcher.deleteUserdata",
+        "title": "Delete Userdata",
+        "category": "Userdata Switcher"
       }
     ]
   },

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -7,6 +7,7 @@ import type { SupportedHostAdapter } from "./host";
 import type { LaunchCommand, LaunchEditor } from "./launcher";
 import {
   CREATE_USERDATA_LABEL,
+  DELETE_USERDATA_LABEL,
   RENAME_CURRENT_USERDATA_LABEL,
   REVEAL_CURRENT_USERDATA_LABEL,
 } from "./menu";
@@ -15,6 +16,7 @@ import { loadRegistry, saveRegistry } from "./registry";
 import {
   activateUserdataSwitcher,
   COMMAND_CREATE_USERDATA,
+  COMMAND_DELETE_USERDATA,
   COMMAND_OPEN_WITH_USERDATA,
   COMMAND_RENAME_CURRENT_USERDATA,
   COMMAND_REVEAL_CURRENT_USERDATA,
@@ -39,6 +41,7 @@ interface TestHarness {
   warnings: string[];
   infos: string[];
   revealedPaths: string[];
+  deletedPaths: string[];
   logs: string[];
   uiEvents: string[];
   quickPickItems: readonly QuickPickItem[][];
@@ -97,6 +100,8 @@ function createTestHarness(input?: {
   inputBoxValues?: readonly (string | undefined)[];
   launchEditorImpl?: LaunchEditor;
   mkdirSync?: UserdataSwitcherActivation["mkdirSync"];
+  deletePathFailure?: boolean;
+  warningMessageChoice?: string;
 }): TestHarness {
   const tempRoot = process.platform === "darwin" ? "/tmp" : os.tmpdir();
   const tempDir = fs.mkdtempSync(
@@ -121,6 +126,7 @@ function createTestHarness(input?: {
   const warnings: string[] = [];
   const infos: string[] = [];
   const revealedPaths: string[] = [];
+  const deletedPaths: string[] = [];
   const logs: string[] = [];
   const uiEvents: string[] = [];
   const quickPickItems: QuickPickItem[][] = [];
@@ -165,14 +171,21 @@ function createTestHarness(input?: {
     showErrorMessage: async (message) => {
       errors.push(message);
     },
-    showWarningMessage: async (message) => {
+    showWarningMessage: async (message, ...items) => {
       warnings.push(message);
+      return input?.warningMessageChoice ?? items[0];
     },
     showInformationMessage: async (message) => {
       infos.push(message);
     },
     revealPathInOs: async (fsPath) => {
       revealedPaths.push(fsPath);
+    },
+    deletePath: async (fsPath) => {
+      if (input?.deletePathFailure) {
+        throw new Error("mock delete failure");
+      }
+      deletedPaths.push(fsPath);
     },
   };
 
@@ -217,6 +230,7 @@ function createTestHarness(input?: {
     warnings,
     infos,
     revealedPaths,
+    deletedPaths,
     logs,
     uiEvents,
     quickPickItems,
@@ -416,6 +430,11 @@ describe("activateUserdataSwitcher", () => {
       {
         label: CREATE_USERDATA_LABEL,
         intent: { kind: "create" },
+        alwaysShow: true,
+      },
+      {
+        label: DELETE_USERDATA_LABEL,
+        intent: { kind: "delete" },
         alwaysShow: true,
       },
     ]);
@@ -839,6 +858,93 @@ describe("activateUserdataSwitcher", () => {
 
     assert.deepEqual(harness.errors, ["spawn failed"]);
   });
+
+  it("deletes the selected managed userdata, removes it from registry, and moves folder to trash", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: "Delete",
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.deletedPaths, [
+      path.join(harness.storeRoot, "u/personal"),
+    ]);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.deepEqual(registry.userdatas, [
+      { id: "default", kind: "default", label: "Default" },
+    ]);
+    assert.deepEqual(harness.infos, ['Userdata "Personal" has been deleted.']);
+  });
+
+  it("does not delete the userdata if user cancels the confirmation dialog", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: "Cancel",
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.deletedPaths, []);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.equal(registry.userdatas.length, 2);
+    assert.deepEqual(harness.infos, []);
+  });
+
+  it("shows warning when no other managed userdatas are available to delete", async () => {
+    const harness = createTestHarness();
+    harnesses.push(harness);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.warnings, [
+      "No other managed userdatas available to delete.",
+    ]);
+    assert.deepEqual(harness.deletedPaths, []);
+  });
+
+  it("handles deletion failure gracefully, keeping the entry in the registry", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: "Delete",
+      deletePathFailure: true,
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.warnings, [
+      'Are you sure you want to delete userdata "Personal"? This will move all its settings and data files to the trash.',
+      "Could not delete userdata folder. It might be open in another window. Please close all windows using this userdata and try again.",
+    ]);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.equal(registry.userdatas.length, 2);
+    assert.ok(registry.userdatas.some((entry) => entry.id === "personal"));
+  });
 });
 
 describe("createVscodeUi", () => {
@@ -859,6 +965,11 @@ describe("createVscodeUi", () => {
               if (cmd === "revealFileInOS") {
                 throw new Error("mock reveal failure");
               }
+            },
+          },
+          workspace: {
+            fs: {
+              delete: async () => {},
             },
           },
           Uri: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,8 @@ export function createVscodeUi(logger: LaunchLogger): UserdataSwitcherUi {
       ) as PromiseLike<QuickPickItem | undefined>,
     showInputBox: (options) => vscode.window.showInputBox(options),
     showErrorMessage: (message) => vscode.window.showErrorMessage(message),
-    showWarningMessage: (message) => vscode.window.showWarningMessage(message),
+    showWarningMessage: (message, ...items) =>
+      vscode.window.showWarningMessage(message, ...items),
     showInformationMessage: (message) =>
       vscode.window.showInformationMessage(message),
     revealPathInOs: async (fsPath) => {
@@ -78,6 +79,16 @@ export function createVscodeUi(logger: LaunchLogger): UserdataSwitcherUi {
         logger.error(`revealFileInOS failed: ${message}`);
         throw error;
       }
+    },
+    deletePath: async (fsPath, options) => {
+      const uri = vscode.Uri.file(fsPath);
+      logger.info(
+        `deletePath fsPath=${JSON.stringify(fsPath)} useTrash=${options.useTrash}`,
+      );
+      await vscode.workspace.fs.delete(uri, {
+        recursive: true,
+        useTrash: options.useTrash,
+      });
     },
   };
 }

--- a/src/host.test.ts
+++ b/src/host.test.ts
@@ -11,9 +11,14 @@ const insiders = resolveEditorHost({
   appName: "Visual Studio Code - Insiders",
   uriScheme: "vscode-insiders",
 });
+const antigravityIde = resolveEditorHost({
+  appName: "Antigravity IDE",
+  uriScheme: "antigravity-ide",
+});
 assert.ok(cursor);
 assert.ok(vscode);
 assert.ok(insiders);
+assert.ok(antigravityIde);
 
 describe("resolveEditorHost", () => {
   it("resolves Cursor from the URI scheme", () => {
@@ -47,6 +52,17 @@ describe("resolveEditorHost", () => {
     assert.equal(host?.id, "vscode-insiders");
     assert.equal(host?.displayName, "Visual Studio Code - Insiders");
     assert.deepEqual(host?.cliNames, ["code-insiders"]);
+  });
+
+  it("resolves Antigravity IDE from the URI scheme", () => {
+    const host = resolveEditorHost({
+      appName: "Antigravity IDE",
+      uriScheme: "antigravity-ide",
+    });
+
+    assert.equal(host?.id, "antigravity-ide");
+    assert.equal(host?.displayName, "Antigravity IDE");
+    assert.deepEqual(host?.cliNames, ["antigravity-ide"]);
   });
 
   it("does not guess unsupported hosts", () => {
@@ -91,6 +107,39 @@ describe("resolveStoreRoot", () => {
         env: {},
       }),
       "C:\\Users\\alice\\AppData\\Local\\udsw\\vscode-insiders",
+    );
+  });
+
+  it("resolves the macOS store root under a host namespace for Antigravity IDE", () => {
+    assert.equal(
+      antigravityIde.resolveStoreRoot({
+        platform: "darwin",
+        home: "/Users/alice",
+        env: {},
+      }),
+      "/Users/alice/Library/Application Support/udsw/antigravity-ide",
+    );
+  });
+
+  it("resolves the Linux store root under a host namespace for Antigravity IDE", () => {
+    assert.equal(
+      antigravityIde.resolveStoreRoot({
+        platform: "linux",
+        home: "/home/alice",
+        env: {},
+      }),
+      "/home/alice/.local/share/udsw/antigravity-ide",
+    );
+  });
+
+  it("resolves the Windows store root under a host namespace for Antigravity IDE", () => {
+    assert.equal(
+      antigravityIde.resolveStoreRoot({
+        platform: "win32",
+        home: "C:\\Users\\alice",
+        env: {},
+      }),
+      "C:\\Users\\alice\\AppData\\Local\\udsw\\antigravity-ide",
     );
   });
 
@@ -140,6 +189,17 @@ describe("resolveDefaultUserdataRoot", () => {
       "C:\\Users\\alice\\AppData\\Roaming\\Code - Insiders",
     );
   });
+
+  it("resolves the Linux default Antigravity IDE userdata root", () => {
+    assert.equal(
+      antigravityIde.resolveDefaultUserdataRoot({
+        platform: "linux",
+        home: "/home/alice",
+        env: {},
+      }),
+      "/home/alice/.config/Antigravity IDE",
+    );
+  });
 });
 
 describe("resolveSharedExtensionsDirectory", () => {
@@ -175,6 +235,17 @@ describe("resolveSharedExtensionsDirectory", () => {
       "C:\\Users\\alice\\.vscode-insiders\\extensions",
     );
   });
+
+  it("resolves the Linux Antigravity IDE shared extensions directory", () => {
+    assert.equal(
+      antigravityIde.resolveSharedExtensionsDirectory({
+        platform: "linux",
+        home: "/home/alice",
+        env: {},
+      }),
+      "/home/alice/.antigravity-ide/extensions",
+    );
+  });
 });
 
 describe("discoverEditorCli bundled discovery", () => {
@@ -203,6 +274,22 @@ describe("discoverEditorCli bundled discovery", () => {
         },
       ),
       "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+    );
+  });
+
+  it("finds the bundled Antigravity IDE CLI under appRoot on Linux", () => {
+    assert.equal(
+      antigravityIde.discoverEditorCli(
+        "/opt/antigravity-ide/Antigravity-IDE/resources/app",
+        {
+          env: { PATH: "/usr/local/bin" },
+          existsSync: (candidate) =>
+            candidate ===
+            "/opt/antigravity-ide/Antigravity-IDE/resources/app/bin/antigravity-ide",
+          platform: "linux",
+        },
+      ),
+      "/opt/antigravity-ide/Antigravity-IDE/resources/app/bin/antigravity-ide",
     );
   });
 

--- a/src/host.ts
+++ b/src/host.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-type EditorHostId = "cursor" | "vscode" | "vscode-insiders";
+type EditorHostId = "cursor" | "vscode" | "vscode-insiders" | "antigravity-ide";
 
 export interface EditorHostIdentity {
   appName: string;
@@ -75,6 +75,15 @@ const HOST_DEFINITIONS: HostDefinition[] = [
     sharedExtensionsRelativePath: ".vscode-insiders/extensions",
     cliNames: ["code-insiders"],
     windowsExecutableNames: ["Code - Insiders.exe"],
+  },
+  {
+    id: "antigravity-ide",
+    displayName: "Antigravity IDE",
+    storageSlug: "antigravity-ide",
+    defaultUserdataDirName: "Antigravity IDE",
+    sharedExtensionsRelativePath: ".antigravity-ide/extensions",
+    cliNames: ["antigravity-ide"],
+    windowsExecutableNames: ["Antigravity IDE.exe", "antigravity-ide.exe"],
   },
 ];
 

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import {
   COMMAND_CREATE_USERDATA,
+  COMMAND_DELETE_USERDATA,
   COMMAND_OPEN_WITH_USERDATA,
   COMMAND_RENAME_CURRENT_USERDATA,
   COMMAND_REVEAL_CURRENT_USERDATA,
@@ -61,6 +62,7 @@ describe("extension manifest", () => {
         COMMAND_RENAME_CURRENT_USERDATA,
         COMMAND_SHOW_CURRENT_USERDATA,
         COMMAND_REVEAL_CURRENT_USERDATA,
+        COMMAND_DELETE_USERDATA,
       ],
     );
     assert.ok(

--- a/src/menu.test.ts
+++ b/src/menu.test.ts
@@ -4,6 +4,7 @@ import {
   ACTIONS_SEPARATOR_LABEL,
   buildOpenWithUserdataMenuItems,
   CREATE_USERDATA_LABEL,
+  DELETE_USERDATA_LABEL,
   RENAME_CURRENT_USERDATA_LABEL,
   REVEAL_CURRENT_USERDATA_LABEL,
   resolveOpenWithUserdataMenuIntent,
@@ -39,7 +40,7 @@ describe("buildOpenWithUserdataMenuItems", () => {
     });
     assert.deepEqual(
       items.map((item) => item.kind ?? "item"),
-      ["separator", "item", "item", "item"],
+      ["separator", "item", "item", "item", "item"],
     );
     assert.equal(items[0]?.label, "Actions");
     assert.equal(items[1]?.label, RENAME_CURRENT_USERDATA_LABEL);
@@ -48,6 +49,8 @@ describe("buildOpenWithUserdataMenuItems", () => {
     assert.deepEqual(items[2]?.intent, { kind: "reveal" });
     assert.equal(items[3]?.label, CREATE_USERDATA_LABEL);
     assert.deepEqual(items[3]?.intent, { kind: "create" });
+    assert.equal(items[4]?.label, DELETE_USERDATA_LABEL);
+    assert.deepEqual(items[4]?.intent, { kind: "delete" });
   });
 
   it("omits rename when the current userdata is unknown", () => {
@@ -56,13 +59,15 @@ describe("buildOpenWithUserdataMenuItems", () => {
     });
     assert.deepEqual(
       items.map((item) => item.kind ?? "item"),
-      ["item", "item", "separator", "item", "item"],
+      ["item", "item", "separator", "item", "item", "item"],
     );
-    assert.equal(items.at(-1)?.label, CREATE_USERDATA_LABEL);
-    assert.equal(items.at(-2)?.label, REVEAL_CURRENT_USERDATA_LABEL);
-    assert.equal(items.at(-3)?.label, "Actions");
-    assert.deepEqual(items.at(-1)?.intent, { kind: "create" });
-    assert.deepEqual(items.at(-2)?.intent, { kind: "reveal" });
+    assert.equal(items.at(-1)?.label, DELETE_USERDATA_LABEL);
+    assert.equal(items.at(-2)?.label, CREATE_USERDATA_LABEL);
+    assert.equal(items.at(-3)?.label, REVEAL_CURRENT_USERDATA_LABEL);
+    assert.equal(items.at(-4)?.label, "Actions");
+    assert.deepEqual(items.at(-1)?.intent, { kind: "delete" });
+    assert.deepEqual(items.at(-2)?.intent, { kind: "create" });
+    assert.deepEqual(items.at(-3)?.intent, { kind: "reveal" });
     assert.ok(items.every((item) => item.intent?.kind !== "rename"));
   });
 
@@ -89,14 +94,16 @@ describe("buildOpenWithUserdataMenuItems", () => {
     );
     assert.deepEqual(
       items.map((item) => item.kind ?? "item"),
-      ["item", "item", "separator", "item", "item", "item"],
+      ["item", "item", "separator", "item", "item", "item", "item"],
     );
-    assert.equal(items.at(-3)?.label, RENAME_CURRENT_USERDATA_LABEL);
-    assert.deepEqual(items.at(-3)?.intent, { kind: "rename" });
-    assert.equal(items.at(-2)?.label, REVEAL_CURRENT_USERDATA_LABEL);
-    assert.deepEqual(items.at(-2)?.intent, { kind: "reveal" });
-    assert.equal(items.at(-1)?.label, CREATE_USERDATA_LABEL);
-    assert.deepEqual(items.at(-1)?.intent, { kind: "create" });
+    assert.equal(items.at(-4)?.label, RENAME_CURRENT_USERDATA_LABEL);
+    assert.deepEqual(items.at(-4)?.intent, { kind: "rename" });
+    assert.equal(items.at(-3)?.label, REVEAL_CURRENT_USERDATA_LABEL);
+    assert.deepEqual(items.at(-3)?.intent, { kind: "reveal" });
+    assert.equal(items.at(-2)?.label, CREATE_USERDATA_LABEL);
+    assert.deepEqual(items.at(-2)?.intent, { kind: "create" });
+    assert.equal(items.at(-1)?.label, DELETE_USERDATA_LABEL);
+    assert.deepEqual(items.at(-1)?.intent, { kind: "delete" });
   });
 
   it("marks action CTAs with structured action data instead of relying on labels", () => {
@@ -120,9 +127,10 @@ describe("buildOpenWithUserdataMenuItems", () => {
     );
 
     const managedItem = items[0];
-    const renameItem = items.at(-3);
-    const revealItem = items.at(-2);
-    const createItem = items.at(-1);
+    const renameItem = items.at(-4);
+    const revealItem = items.at(-3);
+    const createItem = items.at(-2);
+    const deleteItem = items.at(-1);
 
     assert.equal(managedItem?.label, CREATE_USERDATA_LABEL);
     assert.deepEqual(managedItem?.intent, {
@@ -135,6 +143,8 @@ describe("buildOpenWithUserdataMenuItems", () => {
     assert.deepEqual(revealItem?.intent, { kind: "reveal" });
     assert.equal(createItem?.label, CREATE_USERDATA_LABEL);
     assert.deepEqual(createItem?.intent, { kind: "create" });
+    assert.equal(deleteItem?.label, DELETE_USERDATA_LABEL);
+    assert.deepEqual(deleteItem?.intent, { kind: "delete" });
   });
 });
 
@@ -178,11 +188,17 @@ describe("resolveOpenWithUserdataMenuIntent", () => {
     assert.deepEqual(
       resolveOpenWithUserdataMenuIntent(registry, items.at(-1)),
       {
-        kind: "create",
+        kind: "delete",
       },
     );
     assert.deepEqual(
       resolveOpenWithUserdataMenuIntent(registry, items.at(-2)),
+      {
+        kind: "create",
+      },
+    );
+    assert.deepEqual(
+      resolveOpenWithUserdataMenuIntent(registry, items.at(-3)),
       {
         kind: "reveal",
       },

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -8,12 +8,14 @@ export const RENAME_CURRENT_USERDATA_LABEL =
   "$(edit) Rename Current Userdata...";
 export const REVEAL_CURRENT_USERDATA_LABEL =
   "$(folder-opened) Reveal Current Userdata...";
+export const DELETE_USERDATA_LABEL = "$(trash) Delete Userdata...";
 
 type MenuItemKind = "item" | "separator";
 export type UserdataMenuItemIntent =
   | { kind: "create" }
   | { kind: "rename" }
   | { kind: "reveal" }
+  | { kind: "delete" }
   | { kind: "open"; userdataId: string };
 
 export type UserdataMenuIntent =
@@ -21,6 +23,7 @@ export type UserdataMenuIntent =
   | { kind: "create" }
   | { kind: "rename" }
   | { kind: "reveal" }
+  | { kind: "delete" }
   | { kind: "open"; entry: UserdataEntry };
 
 export interface UserdataMenuSelection {
@@ -66,6 +69,11 @@ export function buildOpenWithUserdataMenuItems(
       label: CREATE_USERDATA_LABEL,
       alwaysShow: true,
     },
+    {
+      intent: { kind: "delete" },
+      label: DELETE_USERDATA_LABEL,
+      alwaysShow: true,
+    },
   ];
 
   return [
@@ -88,6 +96,7 @@ export function resolveOpenWithUserdataMenuIntent(
     case "create":
     case "rename":
     case "reveal":
+    case "delete":
       return intent;
     case "open": {
       const entry = registry.userdatas.find(

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -7,6 +7,7 @@ import {
   addManagedUserdata,
   ensureDefaultUserdata,
   loadRegistry,
+  removeUserdata,
   renameUserdata,
 } from "./registry";
 
@@ -88,6 +89,24 @@ describe("registry", () => {
     };
     const updated = renameUserdata(registry, "default", "Work");
     assert.equal(updated.userdatas[0]?.label, "Work");
+    assert.equal(updated.userdatas[0]?.id, "default");
+  });
+
+  it("removes a userdata by its ID", () => {
+    const registry = {
+      version: 1 as const,
+      userdatas: [
+        { id: "default", kind: "default" as const, label: "Default" },
+        {
+          id: "personal",
+          kind: "managed" as const,
+          label: "Personal",
+          relativeDataDir: "u/personal",
+        },
+      ],
+    };
+    const updated = removeUserdata(registry, "personal");
+    assert.equal(updated.userdatas.length, 1);
     assert.equal(updated.userdatas[0]?.id, "default");
   });
 });

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -103,6 +103,13 @@ export function renameUserdata(
   };
 }
 
+export function removeUserdata(registry: Registry, entryId: string): Registry {
+  return {
+    version: 1,
+    userdatas: registry.userdatas.filter((entry) => entry.id !== entryId),
+  };
+}
+
 const NON_ALPHANUMERIC_REGEX = /[^a-z0-9]+/g;
 const LEADING_TRAILING_HYPHENS_REGEX = /^-+|-+$/g;
 const TRAILING_HYPHENS_REGEX = /-+$/g;

--- a/src/userdataSwitcherApp.ts
+++ b/src/userdataSwitcherApp.ts
@@ -20,8 +20,13 @@ import {
   type UserdataMenuItem,
   type UserdataMenuItemIntent,
 } from "./menu";
-import { registryPath } from "./paths";
-import { type Registry, renameUserdata, type UserdataEntry } from "./registry";
+import { registryPath, resolveManagedDataDir } from "./paths";
+import {
+  type Registry,
+  removeUserdata,
+  renameUserdata,
+  type UserdataEntry,
+} from "./registry";
 import { UserdataRegistryStore } from "./registryStore";
 
 export const COMMAND_OPEN_WITH_USERDATA = "userdataSwitcher.openWithUserdata";
@@ -32,6 +37,7 @@ export const COMMAND_SHOW_CURRENT_USERDATA =
   "userdataSwitcher.showCurrentUserdata";
 export const COMMAND_REVEAL_CURRENT_USERDATA =
   "userdataSwitcher.revealCurrentUserdata";
+export const COMMAND_DELETE_USERDATA = "userdataSwitcher.deleteUserdata";
 
 export interface QuickPickItem {
   label: string;
@@ -73,9 +79,13 @@ export interface UserdataSwitcherUi {
     validateInput?(value: string): string | undefined;
   }): PromiseLike<string | undefined>;
   showErrorMessage(message: string): PromiseLike<unknown>;
-  showWarningMessage(message: string): PromiseLike<unknown>;
+  showWarningMessage(
+    message: string,
+    ...items: string[]
+  ): PromiseLike<string | undefined>;
   showInformationMessage(message: string): PromiseLike<unknown>;
   revealPathInOs(fsPath: string): PromiseLike<unknown>;
+  deletePath(fsPath: string, options: { useTrash: boolean }): PromiseLike<void>;
 }
 
 export interface UserdataSwitcherActivation {
@@ -304,6 +314,89 @@ export function activateUserdataSwitcher(
     logger?.info(`Renamed userdata ${current.entry.id} to ${label}`);
   };
 
+  const deleteUserdata = async () => {
+    const currentRegistry = registryStore.read();
+    const current = currentUserdata(currentRegistry);
+    const deletable = currentRegistry.userdatas.filter(
+      (entry) =>
+        entry.kind === "managed" &&
+        (current.kind === "unmanaged" || entry.id !== current.entry.id),
+    );
+
+    if (deletable.length === 0) {
+      await ui.showWarningMessage(
+        "No other managed userdatas available to delete.",
+      );
+      return;
+    }
+
+    const items: QuickPickItem[] = deletable.map((entry) => ({
+      label: formatUserdataLabel({ kind: "known", entry }),
+      description: entry.relativeDataDir ? `u/${entry.id}` : undefined,
+      intent: { kind: "open", userdataId: entry.id },
+    }));
+
+    const selected = await ui.showQuickPick(items, {
+      title: "Delete Userdata",
+      placeHolder: "Select a userdata to delete",
+    });
+
+    if (selected?.intent?.kind !== "open") {
+      logger?.info("Delete userdata cancelled");
+      return;
+    }
+
+    const targetId = selected.intent.userdataId;
+    const targetEntry = deletable.find((entry) => entry.id === targetId);
+    if (!targetEntry?.relativeDataDir) {
+      return;
+    }
+
+    const confirm = await ui.showWarningMessage(
+      `Are you sure you want to delete userdata "${targetEntry.label}"? This will move all its settings and data files to the trash.`,
+      "Delete",
+      "Cancel",
+    );
+
+    if (confirm !== "Delete") {
+      logger?.info("Delete userdata cancelled by user confirmation");
+      return;
+    }
+
+    let targetPath: string;
+    try {
+      targetPath = resolveManagedDataDir(
+        storeRoot,
+        targetEntry.relativeDataDir,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger?.error(`Resolve path failed: ${message}`);
+      await ui.showErrorMessage(message);
+      return;
+    }
+
+    try {
+      await ui.deletePath(targetPath, { useTrash: true });
+      const updatedRegistry = registryStore.update((latest) =>
+        removeUserdata(latest, targetEntry.id),
+      );
+      refreshStatusBar(updatedRegistry);
+      logger?.info(
+        `Deleted userdata ${targetEntry.id} and moved files to trash`,
+      );
+      await ui.showInformationMessage(
+        `Userdata "${targetEntry.label}" has been deleted.`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger?.error(`Delete userdata files failed: ${message}`);
+      await ui.showWarningMessage(
+        `Could not delete userdata folder. It might be open in another window. Please close all windows using this userdata and try again.`,
+      );
+    }
+  };
+
   const openWithUserdataMenu = async () => {
     const currentRegistry = registryStore.read();
     const current = currentUserdata(currentRegistry);
@@ -336,6 +429,10 @@ export function activateUserdataSwitcher(
         logger?.info("Menu intent: reveal current userdata");
         await revealCurrentUserdata();
         return;
+      case "delete":
+        logger?.info("Menu intent: delete userdata");
+        await deleteUserdata();
+        return;
       case "open":
         logger?.info(`Menu intent: open userdata ${intent.entry.id}`);
         await launchEntrySafely(intent.entry);
@@ -361,6 +458,7 @@ export function activateUserdataSwitcher(
   subscribe(
     ui.registerCommand(COMMAND_REVEAL_CURRENT_USERDATA, revealCurrentUserdata),
   );
+  subscribe(ui.registerCommand(COMMAND_DELETE_USERDATA, deleteUserdata));
 
   refreshStatusBar();
 }


### PR DESCRIPTION
This PR implements managed userdata deletion. It adds quick pick actions to delete managed userdatas, moves the directories to the trash via VS Code's native filesystem trash support, and handles cleaning up the entry from registry.json.