### PR TITLE
feat: managed userdata deletion with running-instance preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@
 
 ### Issue tracker
 
-GitHub Issues on `domoarigatomrburato/userdata-switcher`. See `docs/agents/issue-tracker.md`.
+GitHub Issues on `domoarigatomrburato/userdata-switcher`; external PRs are a triage
+surface. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,12 +15,25 @@ Canonical five-role vocabulary with default label strings. See `docs/agents/tria
 
 Single-context — root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.
 
+## Validation gates
+
+**Always run gates in write mode.** Use `npm run fix`, not `npm run check`.
+
+- `npm run fix` — the agent gate. Runs Knip autofixes, then Biome formatting,
+  lint fixes, and import organization (`knip --fix && biome check --write .`).
+- `npm run check` — readonly CI gate (`knip && biome ci .`). Humans and CI use
+  this to verify a clean tree; agents should not substitute it for `fix`.
+
+Treat every automatic change from `fix` as **safe and expected** — formatting,
+lint autofixes, import organization, and Knip cleanup. When `fix` passes, do
+**not** rerun `npm run check`, tests, or other gates solely because `fix`
+mutated files. Rerun tests only when you still need behavioral verification of
+your own code changes.
+
 ## Maintenance lessons
 
 - When changing repository layout, update build scripts, editor tasks, ignore
   rules, packaging rules, and validation commands in the same pass.
-- Use `npm run fix` as the autofixing command. `npm run check` is the readonly
-  CI-style gate and should not mutate files.
 - When deleting an implementation path, remove its runnable commands and stale
   documentation references in the same pass.
 - After packaging-related changes, inspect the produced artifact contents. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Managed userdata deletion from the userdata menu and Command Palette, moving
   files to the system trash and removing the registry entry (thanks
   [@tazztone](https://github.com/tazztone)).
-- Running-instance preflight on macOS and Linux that blocks deletion while the
-  editor IPC socket for the target userdata is still live.
+- Running-instance preflight on macOS and Linux via the editor IPC socket, and on
+  Windows via matching editor processes for the target `--user-data-dir`.
 - **Quit and delete** action that terminates the stray editor process
   (SIGTERM, then SIGKILL) when closing the window did not quit the singleton
   instance. A single confirmation adapts when a running instance is detected;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0
+
+### Added
+
+- Managed userdata deletion from the userdata menu and Command Palette, moving
+  files to the system trash and removing the registry entry (thanks
+  [@tazztone](https://github.com/tazztone)).
+- Running-instance preflight on macOS and Linux that blocks deletion while the
+  editor IPC socket for the target userdata is still live.
+
 ## 1.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [@tazztone](https://github.com/tazztone)).
 - Running-instance preflight on macOS and Linux that blocks deletion while the
   editor IPC socket for the target userdata is still live.
+- **Quit and delete** action that terminates the stray editor process
+  (SIGTERM, then SIGKILL) when closing the window did not quit the singleton
+  instance. A single confirmation adapts when a running instance is detected;
+  success is reported only after quit and folder removal are verified.
 
 ## 1.2.0
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,8 +63,8 @@ _Avoid_: sign-in menu, profile selector
 **Running Userdata Instance**:
 A live editor window or process associated with an Editor Userdata. On macOS and
 Linux, Userdata Switcher detects a running instance by connecting to the editor
-IPC socket (`1.12-main.sock`) under the userdata root before deleting managed
-userdata.
+IPC socket (`*-main.sock`, for example `3.7.-main.sock` in Cursor) under the
+userdata root before deleting managed userdata.
 _Avoid_: Running profile, active sign-in
 
 **Current Userdata**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,7 +61,10 @@ or creating a new Userdata.
 _Avoid_: sign-in menu, profile selector
 
 **Running Userdata Instance**:
-A live editor window or process associated with an Editor Userdata.
+A live editor window or process associated with an Editor Userdata. On macOS and
+Linux, Userdata Switcher detects a running instance by connecting to the editor
+IPC socket (`1.12-main.sock`) under the userdata root before deleting managed
+userdata.
 _Avoid_: Running profile, active sign-in
 
 **Current Userdata**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,10 +61,11 @@ or creating a new Userdata.
 _Avoid_: sign-in menu, profile selector
 
 **Running Userdata Instance**:
-A live editor window or process associated with an Editor Userdata. On macOS and
-Linux, Userdata Switcher detects a running instance by connecting to the editor
-IPC socket (`*-main.sock`, for example `3.7.-main.sock` in Cursor) under the
-userdata root before deleting managed userdata.
+A live editor window or process associated with an Editor Userdata. Userdata
+Switcher detects a running instance before deleting managed userdata by
+connecting to the editor IPC socket (`*-main.sock`, for example `3.7.-main.sock`
+in Cursor) under the userdata root on macOS and Linux, or by matching editor
+processes launched with the target `--user-data-dir` on Windows.
 _Avoid_: Running profile, active sign-in
 
 **Current Userdata**:

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ view and search for **Userdata Switcher**.
 1. Click the Userdata Switcher status bar item, such as `Work (default)`, or run
    `Userdata Switcher: Open With Userdata`.
 2. Choose `Create New Userdata...`.
-3. Choose `Start from current settings` to copy your user settings,
+3. Name the userdata, for example `Personal` or `Client A`.
+4. Choose `Start from current settings` to copy your user settings,
    keybindings, and snippets once, or choose `Start empty` for editor defaults.
-4. Name the userdata, for example `Personal` or `Client A`.
 5. The editor opens a new window for that userdata. Sign in to the account you
    want for that context.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ If you no longer need a managed userdata, you can delete it:
 3. Select the userdata you want to delete.
 4. Confirm the prompt to move its files to your system's Trash/Recycle Bin and remove it from the registry.
 
-You cannot delete the userdata of the currently active window, or the default editor userdata.
+You cannot delete the userdata of the currently active window, the default editor
+userdata, or a userdata that still has open editor windows. Close every window
+using a userdata before deleting it.
 
 ## What Stays Separate
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ If you no longer need a managed userdata, you can delete it:
 
 You cannot delete the userdata of the currently active window or the default editor
 userdata. If an editor instance for the target userdata is still running, the
-confirmation dialog offers **Quit and delete** (macOS and Linux). Closing a window
+confirmation dialog offers **Quit and delete** when a running instance is detected.
+Closing a window
 is not enough — the extension quits the singleton process before trashing files.
 Success is reported only after the instance is gone and the folder is removed.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ view and search for **Userdata Switcher**.
 
 ![Open With Userdata menu](media/screenshot-menu.png)
 
+## Deleting a Userdata
+
+If you no longer need a managed userdata, you can delete it:
+1. Click the status bar item or run `Userdata Switcher: Open With Userdata`.
+2. Choose `Delete Userdata...` (or run `Userdata Switcher: Delete Userdata` directly from the Command Palette).
+3. Select the userdata you want to delete.
+4. Confirm the prompt to move its files to your system's Trash/Recycle Bin and remove it from the registry.
+
+You cannot delete the userdata of the currently active window, or the default editor userdata.
+
 ## What Stays Separate
 
 - **Isolated:** accounts, subscriptions, sessions, chat history, caches, tabs,

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ If you no longer need a managed userdata, you can delete it:
 3. Select the userdata you want to delete.
 4. Confirm the prompt to move its files to your system's Trash/Recycle Bin and remove it from the registry.
 
-You cannot delete the userdata of the currently active window, the default editor
-userdata, or a userdata that still has open editor windows. Close every window
-using a userdata before deleting it.
+You cannot delete the userdata of the currently active window or the default editor
+userdata. If an editor instance for the target userdata is still running, the
+confirmation dialog offers **Quit and delete** (macOS and Linux). Closing a window
+is not enough — the extension quits the singleton process before trashing files.
+Success is reported only after the instance is gone and the folder is removed.
 
 ## What Stays Separate
 

--- a/docs/adr/0001-use-supported-editor-userdata-roots.md
+++ b/docs/adr/0001-use-supported-editor-userdata-roots.md
@@ -110,15 +110,16 @@ removes the registry entry, and refuses deletion when:
 
 - the target is the current window's userdata,
 - the target is the default userdata,
-- or a Running Userdata Instance is detected for the target on macOS/Linux via
-  the editor IPC socket under the userdata root.
+- or a Running Userdata Instance is detected for the target via the editor IPC
+  socket under the userdata root on macOS/Linux, or via matching editor
+  processes for the target `--user-data-dir` on Windows.
 
-When a running instance is detected on macOS/Linux, the confirmation dialog
+When a running instance is detected, the confirmation dialog
 offers **Quit and delete**, which quits that instance before trashing files.
 Success is reported only after quit and folder removal are verified.
 
-On Windows, open-file locking during trash is the secondary guard when IPC
-probing and quit-and-delete are unavailable.
+On Windows, open-file locking during trash remains a secondary guard when
+process detection cannot enumerate command lines.
 
 ## Consequences
 

--- a/docs/adr/0001-use-supported-editor-userdata-roots.md
+++ b/docs/adr/0001-use-supported-editor-userdata-roots.md
@@ -105,6 +105,17 @@ entries, then an `Actions` section with actions such as
 still shown in the title, but arbitrary external userdata roots are not adopted
 in the MVP.
 
+Managed userdata deletion moves the managed directory to the system trash,
+removes the registry entry, and blocks deletion when:
+
+- the target is the current window's userdata,
+- the target is the default userdata,
+- or a Running Userdata Instance is detected for the target on macOS/Linux via
+  the editor IPC socket under the userdata root.
+
+On Windows, open-file locking during trash is the secondary guard when IPC
+probing is unavailable.
+
 ## Consequences
 
 Adding another editor host is a validation task: add an adapter entry only after

--- a/docs/adr/0001-use-supported-editor-userdata-roots.md
+++ b/docs/adr/0001-use-supported-editor-userdata-roots.md
@@ -106,15 +106,19 @@ still shown in the title, but arbitrary external userdata roots are not adopted
 in the MVP.
 
 Managed userdata deletion moves the managed directory to the system trash,
-removes the registry entry, and blocks deletion when:
+removes the registry entry, and refuses deletion when:
 
 - the target is the current window's userdata,
 - the target is the default userdata,
 - or a Running Userdata Instance is detected for the target on macOS/Linux via
   the editor IPC socket under the userdata root.
 
+When a running instance is detected on macOS/Linux, the confirmation dialog
+offers **Quit and delete**, which quits that instance before trashing files.
+Success is reported only after quit and folder removal are verified.
+
 On Windows, open-file locking during trash is the secondary guard when IPC
-probing is unavailable.
+probing and quit-and-delete are unavailable.
 
 ## Consequences
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -16,6 +16,18 @@ remote may still point at an older repository slug during the product rename.
 - **Apply / remove labels**: `gh issue edit <number> --repo domoarigatomrburato/userdata-switcher --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --repo domoarigatomrburato/userdata-switcher --comment "..."`
 
+## Pull requests as a triage surface
+
+**PRs as a request surface: yes.**
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --repo domoarigatomrburato/userdata-switcher --comments` and `gh pr diff <number> --repo domoarigatomrburato/userdata-switcher` for the diff.
+- **List external PRs for triage**: `gh pr list --repo domoarigatomrburato/userdata-switcher --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close` (each with `--repo domoarigatomrburato/userdata-switcher`).
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42 --repo domoarigatomrburato/userdata-switcher` and fall back to `gh issue view 42 --repo domoarigatomrburato/userdata-switcher`.
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.

--- a/docs/strategy/mvp-contract.md
+++ b/docs/strategy/mvp-contract.md
@@ -64,10 +64,11 @@ CTAs.
 
 Create flow:
 
-1. Prompt for a creation mode.
-2. Default to `Start from current settings`.
-3. Offer `Start empty` for fresh editor defaults.
-4. Prompt for a Userdata Label.
+1. Prompt for a Userdata Label.
+2. Prompt for a creation mode with action buttons.
+3. Offer `Start from current settings` to copy safe user preferences from the
+   Current Userdata.
+4. Offer `Start empty` for fresh editor defaults.
 5. Derive a stable id.
 6. Create a Managed Userdata directory under the Userdata Store Root.
 7. For `Start from current settings`, copy safe user preferences from the
@@ -77,7 +78,7 @@ Create flow:
    `globalStorage`, `workspaceStorage`, caches, logs, or extension state.
 9. Persist the registry entry.
 10. Launch the current Supported Host with the new userdata and current workspace
-   when possible.
+    when possible.
 
 Rename changes only the label. It does not affect ids, relative data
 directories, or launch behavior.

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,7 @@
   "$schema": "./node_modules/knip/schema.json",
   "exclude": ["devDependencies"],
   "includeEntryExports": true,
-  "ignoreBinaries": ["ps"],
+  "ignoreBinaries": ["ps", "powershell", "taskkill"],
   "treatConfigHintsAsErrors": true,
   "treatTagHintsAsErrors": true
 }

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/knip/schema.json",
   "exclude": ["devDependencies"],
   "includeEntryExports": true,
+  "ignoreBinaries": ["ps"],
   "treatConfigHintsAsErrors": true,
   "treatTagHintsAsErrors": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userdata-switcher",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "userdata-switcher",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Userdata Switcher",
   "description": "Use Cursor AI subscriptions or VS Code themes side by side, each with separate state.",
   "icon": "media/icon.png",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "commonjs",
   "publisher": "domoarigatomrburato",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
         "command": "userdataSwitcher.revealCurrentUserdata",
         "title": "Reveal Current Userdata",
         "category": "Userdata Switcher"
+      },
+      {
+        "command": "userdataSwitcher.deleteUserdata",
+        "title": "Delete Userdata",
+        "category": "Userdata Switcher"
       }
     ]
   },

--- a/src/deleteManagedUserdata.test.ts
+++ b/src/deleteManagedUserdata.test.ts
@@ -156,4 +156,43 @@ describe("executeManagedUserdataDeletion", () => {
       reason: "instance-still-running",
     });
   });
+
+  it("logs Windows process preflight instead of Unix socket candidates", async () => {
+    const logs: string[] = [];
+
+    await executeManagedUserdataDeletion({
+      targetPath: "C:\\Users\\ale\\AppData\\Local\\udsw\\cursor\\u\\testone",
+      label: "testone",
+      platform: "win32",
+      isManagedUserdataInUse: async () => false,
+      quitManagedUserdataInstance: async () => false,
+      deletePath: async () => {},
+      pathExists: () => false,
+      confirmDeletion: async () => false,
+      logInfo: (message) => logs.push(message),
+    });
+
+    assert.deepEqual(logs, [
+      "Delete preflight: checking for running editor processes (Windows)",
+    ]);
+  });
+
+  it("logs Unix socket candidates during preflight on macOS and Linux", async () => {
+    const logs: string[] = [];
+
+    await executeManagedUserdataDeletion({
+      targetPath: "/store/u/personal",
+      label: "Personal",
+      editorVersion: "1.105.1",
+      platform: "linux",
+      isManagedUserdataInUse: async () => false,
+      quitManagedUserdataInstance: async () => false,
+      deletePath: async () => {},
+      pathExists: () => false,
+      confirmDeletion: async () => false,
+      logInfo: (message) => logs.push(message),
+    });
+
+    assert.match(logs[0] ?? "", /^Delete preflight socket candidates:/);
+  });
 });

--- a/src/deleteManagedUserdata.test.ts
+++ b/src/deleteManagedUserdata.test.ts
@@ -66,6 +66,29 @@ describe("executeManagedUserdataDeletion", () => {
     assert.equal(quitCalled, true);
   });
 
+  it("does not trash files when the instance is running again before delete", async () => {
+    let deleted = false;
+    let probeCount = 0;
+
+    const outcome = await executeManagedUserdataDeletion({
+      targetPath: "/store/u/personal",
+      label: "Personal",
+      isManagedUserdataInUse: async () => {
+        probeCount += 1;
+        return probeCount !== 3;
+      },
+      quitManagedUserdataInstance: async () => true,
+      deletePath: async () => {
+        deleted = true;
+      },
+      pathExists: () => false,
+      confirmDeletion: async () => true,
+    });
+
+    assert.equal(outcome.status, "quit-failed");
+    assert.equal(deleted, false);
+  });
+
   it("does not delete when quit fails for a running instance", async () => {
     let deleted = false;
 

--- a/src/deleteManagedUserdata.test.ts
+++ b/src/deleteManagedUserdata.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildDeleteUserdataConfirmation,
+  executeManagedUserdataDeletion,
+} from "./deleteManagedUserdata";
+import { DELETE_QUIT_AND_DELETE_LABEL } from "./deleteUserdata";
+
+describe("buildDeleteUserdataConfirmation", () => {
+  it("offers a simple delete confirmation when no instance is running", () => {
+    const confirmation = buildDeleteUserdataConfirmation("Personal", false);
+
+    assert.equal(confirmation.confirmLabel, "Delete");
+    assert.match(confirmation.message, /Delete userdata "Personal"/);
+    assert.doesNotMatch(confirmation.message, /still running/);
+  });
+
+  it("offers quit and delete when an instance is still running", () => {
+    const confirmation = buildDeleteUserdataConfirmation("Personal", true);
+
+    assert.equal(confirmation.confirmLabel, DELETE_QUIT_AND_DELETE_LABEL);
+    assert.match(confirmation.message, /still running/);
+    assert.match(confirmation.message, /Quit and delete/);
+  });
+});
+
+describe("executeManagedUserdataDeletion", () => {
+  it("deletes when the user confirms and no instance is running", async () => {
+    let deleted = false;
+
+    const outcome = await executeManagedUserdataDeletion({
+      targetPath: "/store/u/personal",
+      label: "Personal",
+      isManagedUserdataInUse: async () => false,
+      quitManagedUserdataInstance: async () => false,
+      deletePath: async () => {
+        deleted = true;
+      },
+      pathExists: () => false,
+      confirmDeletion: async () => true,
+    });
+
+    assert.equal(outcome.status, "success");
+    assert.equal(deleted, true);
+  });
+
+  it("quits a running instance before deleting when the user confirms quit and delete", async () => {
+    let quitCalled = false;
+    let running = true;
+
+    const outcome = await executeManagedUserdataDeletion({
+      targetPath: "/store/u/personal",
+      label: "Personal",
+      isManagedUserdataInUse: async () => running,
+      quitManagedUserdataInstance: async () => {
+        quitCalled = true;
+        running = false;
+        return true;
+      },
+      deletePath: async () => {},
+      pathExists: () => false,
+      confirmDeletion: async () => true,
+    });
+
+    assert.equal(outcome.status, "success");
+    assert.equal(quitCalled, true);
+  });
+
+  it("does not delete when quit fails for a running instance", async () => {
+    let deleted = false;
+
+    const outcome = await executeManagedUserdataDeletion({
+      targetPath: "/store/u/personal",
+      label: "Personal",
+      isManagedUserdataInUse: async () => true,
+      quitManagedUserdataInstance: async () => false,
+      deletePath: async () => {
+        deleted = true;
+      },
+      pathExists: () => false,
+      confirmDeletion: async () => true,
+    });
+
+    assert.equal(outcome.status, "quit-failed");
+    assert.equal(deleted, false);
+  });
+
+  it("does not report success when the folder still exists after delete", async () => {
+    const outcome = await executeManagedUserdataDeletion({
+      targetPath: "/store/u/personal",
+      label: "Personal",
+      isManagedUserdataInUse: async () => false,
+      quitManagedUserdataInstance: async () => false,
+      deletePath: async () => {},
+      pathExists: () => true,
+      confirmDeletion: async () => true,
+    });
+
+    assert.deepEqual(outcome, {
+      status: "verify-failed",
+      reason: "path-still-exists",
+    });
+  });
+
+  it("does not report success when the instance is still running after delete", async () => {
+    let phase: "initial" | "after-quit" | "after-delete" = "initial";
+
+    const outcome = await executeManagedUserdataDeletion({
+      targetPath: "/store/u/personal",
+      label: "Personal",
+      isManagedUserdataInUse: async () => {
+        if (phase === "initial") {
+          return true;
+        }
+        if (phase === "after-quit") {
+          return false;
+        }
+        return true;
+      },
+      quitManagedUserdataInstance: async () => {
+        phase = "after-quit";
+        return true;
+      },
+      deletePath: async () => {
+        phase = "after-delete";
+      },
+      pathExists: () => false,
+      confirmDeletion: async () => true,
+    });
+
+    assert.deepEqual(outcome, {
+      status: "verify-failed",
+      reason: "instance-still-running",
+    });
+  });
+});

--- a/src/deleteManagedUserdata.ts
+++ b/src/deleteManagedUserdata.ts
@@ -24,6 +24,7 @@ export interface ManagedUserdataDeletionDeps {
   confirmDeletion: (message: string, confirmLabel: string) => Promise<boolean>;
   logInfo?: (message: string) => void;
   logError?: (message: string) => void;
+  platform?: NodeJS.Platform;
 }
 
 export function buildDeleteUserdataConfirmation(
@@ -51,15 +52,7 @@ export async function executeManagedUserdataDeletion(
   const logInfo = deps.logInfo ?? (() => {});
   const logError = deps.logError ?? (() => {});
 
-  const socketCandidates = listMainSocketPaths(
-    deps.targetPath,
-    deps.editorVersion,
-  );
-  logInfo(
-    `Delete preflight socket candidates: ${
-      socketCandidates.length > 0 ? socketCandidates.join(", ") : "(none)"
-    }`,
-  );
+  logDeletePreflight(deps, logInfo);
 
   const instanceRunning = await deps.isManagedUserdataInUse(deps.targetPath);
   const { message, confirmLabel } = buildDeleteUserdataConfirmation(
@@ -98,6 +91,32 @@ export async function executeManagedUserdataDeletion(
   }
 
   return { status: "success" };
+}
+
+function logDeletePreflight(
+  deps: Pick<
+    ManagedUserdataDeletionDeps,
+    "targetPath" | "editorVersion" | "platform"
+  >,
+  logInfo: (message: string) => void,
+): void {
+  const platform = deps.platform ?? process.platform;
+  if (platform === "win32") {
+    logInfo(
+      "Delete preflight: checking for running editor processes (Windows)",
+    );
+    return;
+  }
+
+  const socketCandidates = listMainSocketPaths(
+    deps.targetPath,
+    deps.editorVersion,
+  );
+  logInfo(
+    `Delete preflight socket candidates: ${
+      socketCandidates.length > 0 ? socketCandidates.join(", ") : "(none)"
+    }`,
+  );
 }
 
 async function ensureUserdataInstanceStopped(

--- a/src/deleteManagedUserdata.ts
+++ b/src/deleteManagedUserdata.ts
@@ -23,6 +23,7 @@ export interface ManagedUserdataDeletionDeps {
   pathExists: (managedUserdataRoot: string) => boolean;
   confirmDeletion: (message: string, confirmLabel: string) => Promise<boolean>;
   logInfo?: (message: string) => void;
+  logError?: (message: string) => void;
 }
 
 export function buildDeleteUserdataConfirmation(
@@ -48,6 +49,7 @@ export async function executeManagedUserdataDeletion(
   deps: ManagedUserdataDeletionDeps,
 ): Promise<ManagedUserdataDeletionOutcome> {
   const logInfo = deps.logInfo ?? (() => {});
+  const logError = deps.logError ?? (() => {});
 
   const socketCandidates = listMainSocketPaths(
     deps.targetPath,
@@ -73,9 +75,17 @@ export async function executeManagedUserdataDeletion(
     return { status: "quit-failed" };
   }
 
+  if (await deps.isManagedUserdataInUse(deps.targetPath)) {
+    logInfo(
+      `Delete blocked: editor instance for ${deps.targetPath} is still running before trash`,
+    );
+    return { status: "quit-failed" };
+  }
+
   try {
     await deps.deletePath(deps.targetPath);
-  } catch {
+  } catch (error) {
+    logError(error instanceof Error ? error.message : String(error));
     return { status: "delete-failed" };
   }
 

--- a/src/deleteManagedUserdata.ts
+++ b/src/deleteManagedUserdata.ts
@@ -1,0 +1,118 @@
+import { DELETE_QUIT_AND_DELETE_LABEL } from "./deleteUserdata";
+import { listMainSocketPaths } from "./editorIpc";
+
+export type ManagedUserdataDeletionOutcome =
+  | { status: "cancelled" }
+  | { status: "success" }
+  | { status: "quit-failed" }
+  | { status: "delete-failed" }
+  | {
+      status: "verify-failed";
+      reason: "path-still-exists" | "instance-still-running";
+    };
+
+export interface ManagedUserdataDeletionDeps {
+  targetPath: string;
+  label: string;
+  editorVersion?: string;
+  isManagedUserdataInUse: (managedUserdataRoot: string) => Promise<boolean>;
+  quitManagedUserdataInstance: (
+    managedUserdataRoot: string,
+  ) => Promise<boolean>;
+  deletePath: (managedUserdataRoot: string) => Promise<void>;
+  pathExists: (managedUserdataRoot: string) => boolean;
+  confirmDeletion: (message: string, confirmLabel: string) => Promise<boolean>;
+  logInfo?: (message: string) => void;
+}
+
+export function buildDeleteUserdataConfirmation(
+  label: string,
+  instanceRunning: boolean,
+): { message: string; confirmLabel: string } {
+  const trashNote = "Its settings and data files will be moved to the trash.";
+
+  if (instanceRunning) {
+    return {
+      message: `Delete userdata "${label}"? An editor instance for it is still running — closing its window is not enough. Quit and delete will quit that instance first, then delete the files. ${trashNote}`,
+      confirmLabel: DELETE_QUIT_AND_DELETE_LABEL,
+    };
+  }
+
+  return {
+    message: `Delete userdata "${label}"? ${trashNote}`,
+    confirmLabel: "Delete",
+  };
+}
+
+export async function executeManagedUserdataDeletion(
+  deps: ManagedUserdataDeletionDeps,
+): Promise<ManagedUserdataDeletionOutcome> {
+  const logInfo = deps.logInfo ?? (() => {});
+
+  const socketCandidates = listMainSocketPaths(
+    deps.targetPath,
+    deps.editorVersion,
+  );
+  logInfo(
+    `Delete preflight socket candidates: ${
+      socketCandidates.length > 0 ? socketCandidates.join(", ") : "(none)"
+    }`,
+  );
+
+  const instanceRunning = await deps.isManagedUserdataInUse(deps.targetPath);
+  const { message, confirmLabel } = buildDeleteUserdataConfirmation(
+    deps.label,
+    instanceRunning,
+  );
+
+  if (!(await deps.confirmDeletion(message, confirmLabel))) {
+    return { status: "cancelled" };
+  }
+
+  if (!(await ensureUserdataInstanceStopped(deps, logInfo))) {
+    return { status: "quit-failed" };
+  }
+
+  try {
+    await deps.deletePath(deps.targetPath);
+  } catch {
+    return { status: "delete-failed" };
+  }
+
+  if (deps.pathExists(deps.targetPath)) {
+    return { status: "verify-failed", reason: "path-still-exists" };
+  }
+
+  if (await deps.isManagedUserdataInUse(deps.targetPath)) {
+    return { status: "verify-failed", reason: "instance-still-running" };
+  }
+
+  return { status: "success" };
+}
+
+async function ensureUserdataInstanceStopped(
+  deps: Pick<
+    ManagedUserdataDeletionDeps,
+    "targetPath" | "isManagedUserdataInUse" | "quitManagedUserdataInstance"
+  >,
+  logInfo: (message: string) => void,
+): Promise<boolean> {
+  if (!(await deps.isManagedUserdataInUse(deps.targetPath))) {
+    return true;
+  }
+
+  logInfo(
+    `Attempting to quit editor instance for userdata at ${deps.targetPath}`,
+  );
+  const quit = await deps.quitManagedUserdataInstance(deps.targetPath);
+  if (!quit) {
+    return false;
+  }
+
+  if (await deps.isManagedUserdataInUse(deps.targetPath)) {
+    return false;
+  }
+
+  logInfo(`Editor instance quit successfully for ${deps.targetPath}`);
+  return true;
+}

--- a/src/deleteUserdata.test.ts
+++ b/src/deleteUserdata.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DELETE_BLOCKED_CURRENT_WINDOW_MESSAGE,
+  DELETE_NO_MANAGED_MESSAGE,
+  describeDeleteUserdataBlockedReason,
+  listDeletableManagedUserdatas,
+} from "./deleteUserdata";
+import type { Registry } from "./registry";
+
+const defaultOnlyRegistry: Registry = {
+  version: 1,
+  userdatas: [{ id: "default", kind: "default", label: "Default" }],
+};
+
+const workAndPersonalRegistry: Registry = {
+  version: 1,
+  userdatas: [
+    { id: "default", kind: "default", label: "Default" },
+    {
+      id: "work",
+      kind: "managed",
+      label: "Work",
+      relativeDataDir: "u/work",
+    },
+    {
+      id: "personal",
+      kind: "managed",
+      label: "Personal",
+      relativeDataDir: "u/personal",
+    },
+  ],
+};
+
+describe("listDeletableManagedUserdatas", () => {
+  it("excludes the current managed userdata", () => {
+    const deletable = listDeletableManagedUserdatas(workAndPersonalRegistry, {
+      kind: "known",
+      entry: {
+        id: "work",
+        kind: "managed",
+        label: "Work",
+        relativeDataDir: "u/work",
+      },
+    });
+
+    assert.deepEqual(
+      deletable.map((entry) => entry.id),
+      ["personal"],
+    );
+  });
+
+  it("never includes the default userdata", () => {
+    const deletable = listDeletableManagedUserdatas(workAndPersonalRegistry, {
+      kind: "known",
+      entry: {
+        id: "default",
+        kind: "default",
+        label: "Default",
+      },
+    });
+
+    assert.deepEqual(
+      deletable.map((entry) => entry.id),
+      ["work", "personal"],
+    );
+  });
+});
+
+describe("describeDeleteUserdataBlockedReason", () => {
+  it("explains when the current window is the only managed userdata", () => {
+    const registry: Registry = {
+      version: 1,
+      userdatas: [
+        { id: "default", kind: "default", label: "Default" },
+        {
+          id: "personal",
+          kind: "managed",
+          label: "Personal",
+          relativeDataDir: "u/personal",
+        },
+      ],
+    };
+
+    assert.equal(
+      describeDeleteUserdataBlockedReason(registry, {
+        kind: "known",
+        entry: {
+          id: "personal",
+          kind: "managed",
+          label: "Personal",
+          relativeDataDir: "u/personal",
+        },
+      }),
+      DELETE_BLOCKED_CURRENT_WINDOW_MESSAGE,
+    );
+  });
+
+  it("reports when there are no managed userdatas to delete", () => {
+    assert.equal(
+      describeDeleteUserdataBlockedReason(defaultOnlyRegistry, {
+        kind: "known",
+        entry: {
+          id: "default",
+          kind: "default",
+          label: "Default",
+        },
+      }),
+      DELETE_NO_MANAGED_MESSAGE,
+    );
+  });
+});

--- a/src/deleteUserdata.ts
+++ b/src/deleteUserdata.ts
@@ -6,11 +6,19 @@ export const DELETE_BLOCKED_CURRENT_WINDOW_MESSAGE =
 
 export const DELETE_NO_MANAGED_MESSAGE = "No managed userdatas to delete.";
 
-export const DELETE_IN_USE_MESSAGE =
-  "Close all windows using this userdata, then try deleting again.";
+export const DELETE_QUIT_AND_DELETE_LABEL = "Quit and delete";
+
+export const DELETE_QUIT_FAILED_MESSAGE =
+  "Could not quit the editor instance for this userdata. Quit it manually from its menu bar icon (Cmd+Q on macOS), then try again.";
 
 export const DELETE_TRASH_FAILURE_MESSAGE =
-  "Could not delete userdata folder. It might be open in another window. Please close all windows using this userdata and try again.";
+  "Could not delete the userdata folder. Quit any running instance for it, then try again.";
+
+export const DELETE_VERIFY_PATH_STILL_EXISTS_MESSAGE =
+  "The userdata folder could not be removed. Quit any running instance for it, then try again.";
+
+export const DELETE_VERIFY_INSTANCE_STILL_RUNNING_MESSAGE =
+  "The editor instance for this userdata is still running after deletion was attempted. Quit it manually, then try again.";
 
 export function listDeletableManagedUserdatas(
   registry: Registry,

--- a/src/deleteUserdata.ts
+++ b/src/deleteUserdata.ts
@@ -9,7 +9,7 @@ export const DELETE_NO_MANAGED_MESSAGE = "No managed userdatas to delete.";
 export const DELETE_QUIT_AND_DELETE_LABEL = "Quit and delete";
 
 export const DELETE_QUIT_FAILED_MESSAGE =
-  "Could not quit the editor instance for this userdata. Quit it manually from its menu bar icon (Cmd+Q on macOS), then try again.";
+  "Could not quit the editor instance for this userdata. Quit that editor instance manually, then try again.";
 
 export const DELETE_TRASH_FAILURE_MESSAGE =
   "Could not delete the userdata folder. Quit any running instance for it, then try again.";

--- a/src/deleteUserdata.ts
+++ b/src/deleteUserdata.ts
@@ -1,0 +1,46 @@
+import type { CurrentUserdata } from "./detect";
+import type { Registry, UserdataEntry } from "./registry";
+
+export const DELETE_BLOCKED_CURRENT_WINDOW_MESSAGE =
+  "You can't delete the userdata this window is using. Open or switch to another userdata window, then delete it from there.";
+
+export const DELETE_NO_MANAGED_MESSAGE = "No managed userdatas to delete.";
+
+export const DELETE_IN_USE_MESSAGE =
+  "Close all windows using this userdata, then try deleting again.";
+
+export const DELETE_TRASH_FAILURE_MESSAGE =
+  "Could not delete userdata folder. It might be open in another window. Please close all windows using this userdata and try again.";
+
+export function listDeletableManagedUserdatas(
+  registry: Registry,
+  current: CurrentUserdata,
+): UserdataEntry[] {
+  return registry.userdatas.filter(
+    (entry) =>
+      entry.kind === "managed" &&
+      (current.kind === "unmanaged" || entry.id !== current.entry.id),
+  );
+}
+
+export function describeDeleteUserdataBlockedReason(
+  registry: Registry,
+  current: CurrentUserdata,
+): string | null {
+  if (listDeletableManagedUserdatas(registry, current).length > 0) {
+    return null;
+  }
+
+  const managedCount = registry.userdatas.filter(
+    (entry) => entry.kind === "managed",
+  ).length;
+  if (
+    managedCount > 0 &&
+    current.kind === "known" &&
+    current.entry.kind === "managed"
+  ) {
+    return DELETE_BLOCKED_CURRENT_WINDOW_MESSAGE;
+  }
+
+  return DELETE_NO_MANAGED_MESSAGE;
+}

--- a/src/editorIpc.test.ts
+++ b/src/editorIpc.test.ts
@@ -77,6 +77,17 @@ describe("probeRunningUserdataInstance", () => {
     assert.equal(result, "not-running");
   });
 
+  it("treats a hung IPC connection attempt as not running", async () => {
+    const result = await probeRunningUserdataInstance("/store/u/personal", {
+      platform: "linux",
+      readdirSync: () => ["1.10-main.sock"],
+      connectTimeoutMs: 25,
+      connect: () => new Promise(() => {}),
+    });
+
+    assert.equal(result, "not-running");
+  });
+
   it("skips the IPC probe on Windows and relies on delete failure instead", async () => {
     const result = await probeRunningUserdataInstance("/store/u/personal", {
       platform: "win32",

--- a/src/editorIpc.test.ts
+++ b/src/editorIpc.test.ts
@@ -1,25 +1,57 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  listMainSocketPaths,
+  mainSocketBasenameForEditorVersion,
   mainSocketPath,
   probeRunningUserdataInstance,
-  VSCODE_MAIN_SOCKET_BASENAME,
 } from "./editorIpc";
 
-describe("mainSocketPath", () => {
-  it("joins the VS Code main IPC socket basename under the userdata root", () => {
+describe("mainSocketBasenameForEditorVersion", () => {
+  it("matches VS Code socket naming for API versions", () => {
     assert.equal(
-      mainSocketPath("/store/u/personal"),
-      `/store/u/personal/${VSCODE_MAIN_SOCKET_BASENAME}`,
+      mainSocketBasenameForEditorVersion("1.105.1"),
+      "1.10-main.sock",
+    );
+  });
+
+  it("matches Cursor product socket naming", () => {
+    assert.equal(
+      mainSocketBasenameForEditorVersion("3.7.42"),
+      "3.7.-main.sock",
+    );
+  });
+});
+
+describe("listMainSocketPaths", () => {
+  it("discovers versioned main sockets in the userdata root", () => {
+    assert.deepEqual(
+      listMainSocketPaths("/store/u/personal", "1.105.1", () => [
+        "Cache",
+        "3.7.-main.sock",
+      ]),
+      ["/store/u/personal/1.10-main.sock", "/store/u/personal/3.7.-main.sock"],
+    );
+  });
+});
+
+describe("mainSocketPath", () => {
+  it("joins the editor-version socket basename under the userdata root", () => {
+    assert.equal(
+      mainSocketPath("/store/u/personal", "1.105.1"),
+      "/store/u/personal/1.10-main.sock",
     );
   });
 });
 
 describe("probeRunningUserdataInstance", () => {
-  it("reports running when the IPC socket accepts a connection", async () => {
+  it("reports running when any discovered IPC socket accepts a connection", async () => {
     const result = await probeRunningUserdataInstance("/store/u/personal", {
       platform: "linux",
-      connect: async () => "connected",
+      editorVersion: "1.105.1",
+      readdirSync: () => ["3.7.-main.sock"],
+      connect: async (socketPath) =>
+        socketPath.endsWith("3.7.-main.sock") ? "connected" : "missing",
     });
 
     assert.equal(result, "running");
@@ -28,6 +60,7 @@ describe("probeRunningUserdataInstance", () => {
   it("reports not running when the IPC socket file is missing", async () => {
     const result = await probeRunningUserdataInstance("/store/u/personal", {
       platform: "darwin",
+      readdirSync: () => [],
       connect: async () => "missing",
     });
 
@@ -37,6 +70,7 @@ describe("probeRunningUserdataInstance", () => {
   it("reports not running when the IPC socket is stale", async () => {
     const result = await probeRunningUserdataInstance("/store/u/personal", {
       platform: "linux",
+      readdirSync: () => ["3.7.-main.sock"],
       connect: async () => "refused",
     });
 

--- a/src/editorIpc.test.ts
+++ b/src/editorIpc.test.ts
@@ -88,7 +88,7 @@ describe("probeRunningUserdataInstance", () => {
     assert.equal(result, "not-running");
   });
 
-  it("skips the IPC probe on Windows and relies on delete failure instead", async () => {
+  it("skips Unix socket connect on Windows", async () => {
     const result = await probeRunningUserdataInstance("/store/u/personal", {
       platform: "win32",
       connect: async () => {

--- a/src/editorIpc.test.ts
+++ b/src/editorIpc.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  mainSocketPath,
+  probeRunningUserdataInstance,
+  VSCODE_MAIN_SOCKET_BASENAME,
+} from "./editorIpc";
+
+describe("mainSocketPath", () => {
+  it("joins the VS Code main IPC socket basename under the userdata root", () => {
+    assert.equal(
+      mainSocketPath("/store/u/personal"),
+      `/store/u/personal/${VSCODE_MAIN_SOCKET_BASENAME}`,
+    );
+  });
+});
+
+describe("probeRunningUserdataInstance", () => {
+  it("reports running when the IPC socket accepts a connection", async () => {
+    const result = await probeRunningUserdataInstance("/store/u/personal", {
+      platform: "linux",
+      connect: async () => "connected",
+    });
+
+    assert.equal(result, "running");
+  });
+
+  it("reports not running when the IPC socket file is missing", async () => {
+    const result = await probeRunningUserdataInstance("/store/u/personal", {
+      platform: "darwin",
+      connect: async () => "missing",
+    });
+
+    assert.equal(result, "not-running");
+  });
+
+  it("reports not running when the IPC socket is stale", async () => {
+    const result = await probeRunningUserdataInstance("/store/u/personal", {
+      platform: "linux",
+      connect: async () => "refused",
+    });
+
+    assert.equal(result, "not-running");
+  });
+
+  it("skips the IPC probe on Windows and relies on delete failure instead", async () => {
+    const result = await probeRunningUserdataInstance("/store/u/personal", {
+      platform: "win32",
+      connect: async () => {
+        throw new Error("connect should not run on win32");
+      },
+    });
+
+    assert.equal(result, "not-running");
+  });
+});

--- a/src/editorIpc.ts
+++ b/src/editorIpc.ts
@@ -1,19 +1,67 @@
+import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 
-export const VSCODE_MAIN_SOCKET_BASENAME = "1.12-main.sock";
+/** @deprecated Use {@link mainSocketBasenameForEditorVersion} or socket discovery. */
+const VSCODE_MAIN_SOCKET_BASENAME = "1.12-main.sock";
+
+const MAIN_SOCKET_SUFFIX = "-main.sock";
 
 export type RunningInstanceProbeResult = "running" | "not-running";
 
 export interface RunningInstanceProbeDeps {
   platform?: NodeJS.Platform;
+  editorVersion?: string;
+  readdirSync?: (directory: string) => string[];
   connect?: (
     socketPath: string,
   ) => Promise<"connected" | "missing" | "refused" | "error">;
 }
 
-export function mainSocketPath(userdataRoot: string): string {
-  return path.join(userdataRoot, VSCODE_MAIN_SOCKET_BASENAME);
+export function mainSocketBasenameForEditorVersion(version: string): string {
+  const versionForSocket = version.slice(0, 4);
+  const typeForSocket = "main".slice(0, 6);
+  return `${versionForSocket}-${typeForSocket}.sock`;
+}
+
+export function listMainSocketPaths(
+  userdataRoot: string,
+  editorVersion?: string,
+  readdirSync: (directory: string) => string[] = fs.readdirSync,
+): string[] {
+  const candidates = new Set<string>();
+  if (editorVersion) {
+    candidates.add(
+      path.join(
+        userdataRoot,
+        mainSocketBasenameForEditorVersion(editorVersion),
+      ),
+    );
+  }
+
+  try {
+    for (const entry of readdirSync(userdataRoot)) {
+      if (entry.endsWith(MAIN_SOCKET_SUFFIX)) {
+        candidates.add(path.join(userdataRoot, entry));
+      }
+    }
+  } catch {
+    return [...candidates];
+  }
+
+  return [...candidates];
+}
+
+export function mainSocketPath(
+  userdataRoot: string,
+  editorVersion?: string,
+): string {
+  return path.join(
+    userdataRoot,
+    editorVersion
+      ? mainSocketBasenameForEditorVersion(editorVersion)
+      : VSCODE_MAIN_SOCKET_BASENAME,
+  );
 }
 
 export async function probeRunningUserdataInstance(
@@ -25,9 +73,20 @@ export async function probeRunningUserdataInstance(
     return "not-running";
   }
 
-  const socketPath = mainSocketPath(userdataRoot);
-  const result = await (deps.connect ?? defaultConnect)(socketPath);
-  return result === "connected" ? "running" : "not-running";
+  const socketPaths = listMainSocketPaths(
+    userdataRoot,
+    deps.editorVersion,
+    deps.readdirSync,
+  );
+
+  for (const socketPath of socketPaths) {
+    const result = await (deps.connect ?? defaultConnect)(socketPath);
+    if (result === "connected") {
+      return "running";
+    }
+  }
+
+  return "not-running";
 }
 
 function defaultConnect(

--- a/src/editorIpc.ts
+++ b/src/editorIpc.ts
@@ -6,16 +6,18 @@ import path from "node:path";
 const VSCODE_MAIN_SOCKET_BASENAME = "1.12-main.sock";
 
 const MAIN_SOCKET_SUFFIX = "-main.sock";
+const DEFAULT_IPC_CONNECT_TIMEOUT_MS = 2_000;
 
 export type RunningInstanceProbeResult = "running" | "not-running";
+
+type ConnectResult = "connected" | "missing" | "refused" | "error";
 
 export interface RunningInstanceProbeDeps {
   platform?: NodeJS.Platform;
   editorVersion?: string;
+  connectTimeoutMs?: number;
   readdirSync?: (directory: string) => string[];
-  connect?: (
-    socketPath: string,
-  ) => Promise<"connected" | "missing" | "refused" | "error">;
+  connect?: (socketPath: string) => Promise<ConnectResult>;
 }
 
 export function mainSocketBasenameForEditorVersion(version: string): string {
@@ -79,8 +81,12 @@ export async function probeRunningUserdataInstance(
     deps.readdirSync,
   );
 
+  const connect =
+    deps.connect ?? ((socketPath: string) => defaultConnect(socketPath));
+  const timeoutMs = deps.connectTimeoutMs ?? DEFAULT_IPC_CONNECT_TIMEOUT_MS;
+
   for (const socketPath of socketPaths) {
-    const result = await (deps.connect ?? defaultConnect)(socketPath);
+    const result = await connectWithTimeout(socketPath, connect, timeoutMs);
     if (result === "connected") {
       return "running";
     }
@@ -89,13 +95,31 @@ export async function probeRunningUserdataInstance(
   return "not-running";
 }
 
-function defaultConnect(
+async function connectWithTimeout(
   socketPath: string,
-): Promise<"connected" | "missing" | "refused" | "error"> {
+  connect: (socketPath: string) => Promise<ConnectResult>,
+  timeoutMs: number,
+): Promise<ConnectResult> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      connect(socketPath),
+      new Promise<ConnectResult>((resolve) => {
+        timer = setTimeout(() => resolve("error"), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function defaultConnect(socketPath: string): Promise<ConnectResult> {
   return new Promise((resolve) => {
     const client = net.connect(socketPath);
 
-    const finish = (result: "connected" | "missing" | "refused" | "error") => {
+    const finish = (result: ConnectResult) => {
       client.removeAllListeners();
       client.destroy();
       resolve(result);

--- a/src/editorIpc.ts
+++ b/src/editorIpc.ts
@@ -1,0 +1,58 @@
+import net from "node:net";
+import path from "node:path";
+
+export const VSCODE_MAIN_SOCKET_BASENAME = "1.12-main.sock";
+
+export type RunningInstanceProbeResult = "running" | "not-running";
+
+export interface RunningInstanceProbeDeps {
+  platform?: NodeJS.Platform;
+  connect?: (
+    socketPath: string,
+  ) => Promise<"connected" | "missing" | "refused" | "error">;
+}
+
+export function mainSocketPath(userdataRoot: string): string {
+  return path.join(userdataRoot, VSCODE_MAIN_SOCKET_BASENAME);
+}
+
+export async function probeRunningUserdataInstance(
+  userdataRoot: string,
+  deps: RunningInstanceProbeDeps = {},
+): Promise<RunningInstanceProbeResult> {
+  const platform = deps.platform ?? process.platform;
+  if (platform === "win32") {
+    return "not-running";
+  }
+
+  const socketPath = mainSocketPath(userdataRoot);
+  const result = await (deps.connect ?? defaultConnect)(socketPath);
+  return result === "connected" ? "running" : "not-running";
+}
+
+function defaultConnect(
+  socketPath: string,
+): Promise<"connected" | "missing" | "refused" | "error"> {
+  return new Promise((resolve) => {
+    const client = net.connect(socketPath);
+
+    const finish = (result: "connected" | "missing" | "refused" | "error") => {
+      client.removeAllListeners();
+      client.destroy();
+      resolve(result);
+    };
+
+    client.once("connect", () => finish("connected"));
+    client.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") {
+        finish("missing");
+        return;
+      }
+      if (error.code === "ECONNREFUSED") {
+        finish("refused");
+        return;
+      }
+      finish("error");
+    });
+  });
+}

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -7,6 +7,7 @@ import type { SupportedHostAdapter } from "./host";
 import type { LaunchCommand, LaunchEditor } from "./launcher";
 import {
   CREATE_USERDATA_LABEL,
+  DELETE_USERDATA_LABEL,
   RENAME_CURRENT_USERDATA_LABEL,
   REVEAL_CURRENT_USERDATA_LABEL,
 } from "./menu";
@@ -15,6 +16,7 @@ import { loadRegistry, saveRegistry } from "./registry";
 import {
   activateUserdataSwitcher,
   COMMAND_CREATE_USERDATA,
+  COMMAND_DELETE_USERDATA,
   COMMAND_OPEN_WITH_USERDATA,
   COMMAND_RENAME_CURRENT_USERDATA,
   COMMAND_REVEAL_CURRENT_USERDATA,
@@ -39,6 +41,7 @@ interface TestHarness {
   warnings: string[];
   infos: string[];
   revealedPaths: string[];
+  deletedPaths: string[];
   logs: string[];
   uiEvents: string[];
   quickPickItems: readonly QuickPickItem[][];
@@ -97,6 +100,8 @@ function createTestHarness(input?: {
   inputBoxValues?: readonly (string | undefined)[];
   launchEditorImpl?: LaunchEditor;
   mkdirSync?: UserdataSwitcherActivation["mkdirSync"];
+  deletePathFailure?: boolean;
+  warningMessageChoice?: string;
 }): TestHarness {
   const tempRoot = process.platform === "darwin" ? "/tmp" : os.tmpdir();
   const tempDir = fs.mkdtempSync(
@@ -121,6 +126,7 @@ function createTestHarness(input?: {
   const warnings: string[] = [];
   const infos: string[] = [];
   const revealedPaths: string[] = [];
+  const deletedPaths: string[] = [];
   const logs: string[] = [];
   const uiEvents: string[] = [];
   const quickPickItems: QuickPickItem[][] = [];
@@ -165,14 +171,21 @@ function createTestHarness(input?: {
     showErrorMessage: async (message) => {
       errors.push(message);
     },
-    showWarningMessage: async (message) => {
+    showWarningMessage: async (message, ...items) => {
       warnings.push(message);
+      return input?.warningMessageChoice ?? items[0];
     },
     showInformationMessage: async (message) => {
       infos.push(message);
     },
     revealPathInOs: async (fsPath) => {
       revealedPaths.push(fsPath);
+    },
+    deletePath: async (fsPath) => {
+      if (input?.deletePathFailure) {
+        throw new Error("mock delete failure");
+      }
+      deletedPaths.push(fsPath);
     },
   };
 
@@ -217,6 +230,7 @@ function createTestHarness(input?: {
     warnings,
     infos,
     revealedPaths,
+    deletedPaths,
     logs,
     uiEvents,
     quickPickItems,
@@ -416,6 +430,11 @@ describe("activateUserdataSwitcher", () => {
       {
         label: CREATE_USERDATA_LABEL,
         intent: { kind: "create" },
+        alwaysShow: true,
+      },
+      {
+        label: DELETE_USERDATA_LABEL,
+        intent: { kind: "delete" },
         alwaysShow: true,
       },
     ]);
@@ -839,6 +858,93 @@ describe("activateUserdataSwitcher", () => {
 
     assert.deepEqual(harness.errors, ["spawn failed"]);
   });
+
+  it("deletes the selected managed userdata, removes it from registry, and moves folder to trash", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: "Delete",
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.deletedPaths, [
+      path.join(harness.storeRoot, "u/personal"),
+    ]);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.deepEqual(registry.userdatas, [
+      { id: "default", kind: "default", label: "Default" },
+    ]);
+    assert.deepEqual(harness.infos, ['Userdata "Personal" has been deleted.']);
+  });
+
+  it("does not delete the userdata if user cancels the confirmation dialog", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: "Cancel",
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.deletedPaths, []);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.equal(registry.userdatas.length, 2);
+    assert.deepEqual(harness.infos, []);
+  });
+
+  it("shows warning when no other managed userdatas are available to delete", async () => {
+    const harness = createTestHarness();
+    harnesses.push(harness);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.warnings, [
+      "No other managed userdatas available to delete.",
+    ]);
+    assert.deepEqual(harness.deletedPaths, []);
+  });
+
+  it("handles deletion failure gracefully, keeping the entry in the registry", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: "Delete",
+      deletePathFailure: true,
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.warnings, [
+      'Are you sure you want to delete userdata "Personal"? This will move all its settings and data files to the trash.',
+      "Could not delete userdata folder. It might be open in another window. Please close all windows using this userdata and try again.",
+    ]);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.equal(registry.userdatas.length, 2);
+    assert.ok(registry.userdatas.some((entry) => entry.id === "personal"));
+  });
 });
 
 describe("createVscodeUi", () => {
@@ -859,6 +965,11 @@ describe("createVscodeUi", () => {
               if (cmd === "revealFileInOS") {
                 throw new Error("mock reveal failure");
               }
+            },
+          },
+          workspace: {
+            fs: {
+              delete: async () => {},
             },
           },
           Uri: {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -3,6 +3,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { after, describe, it } from "node:test";
+import {
+  DELETE_BLOCKED_CURRENT_WINDOW_MESSAGE,
+  DELETE_IN_USE_MESSAGE,
+  DELETE_NO_MANAGED_MESSAGE,
+  DELETE_TRASH_FAILURE_MESSAGE,
+} from "./deleteUserdata";
 import type { SupportedHostAdapter } from "./host";
 import type { LaunchCommand, LaunchEditor } from "./launcher";
 import {
@@ -102,6 +108,7 @@ function createTestHarness(input?: {
   mkdirSync?: UserdataSwitcherActivation["mkdirSync"];
   deletePathFailure?: boolean;
   warningMessageChoice?: string;
+  isManagedUserdataInUse?: UserdataSwitcherActivation["isManagedUserdataInUse"];
 }): TestHarness {
   const tempRoot = process.platform === "darwin" ? "/tmp" : os.tmpdir();
   const tempDir = fs.mkdtempSync(
@@ -214,6 +221,7 @@ function createTestHarness(input?: {
         createdDirs.push(directory);
         fs.mkdirSync(directory, options);
       }),
+    isManagedUserdataInUse: input?.isManagedUserdataInUse,
   };
 
   return {
@@ -907,17 +915,58 @@ describe("activateUserdataSwitcher", () => {
     assert.deepEqual(harness.infos, []);
   });
 
-  it("shows warning when no other managed userdatas are available to delete", async () => {
+  it("shows warning when there are no managed userdatas to delete", async () => {
     const harness = createTestHarness();
     harnesses.push(harness);
 
     activateUserdataSwitcher(harness.activation);
     await harness.run(COMMAND_DELETE_USERDATA);
 
-    assert.deepEqual(harness.warnings, [
-      "No other managed userdatas available to delete.",
-    ]);
+    assert.deepEqual(harness.warnings, [DELETE_NO_MANAGED_MESSAGE]);
     assert.deepEqual(harness.deletedPaths, []);
+  });
+
+  it("blocks deleting the current window managed userdata", async () => {
+    const harness = createTestHarness();
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+    harness.activation.globalStoragePath = globalStoragePathFor(
+      path.join(harness.storeRoot, "u/personal"),
+    );
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.warnings, [DELETE_BLOCKED_CURRENT_WINDOW_MESSAGE]);
+    assert.deepEqual(harness.deletedPaths, []);
+  });
+
+  it("blocks deletion when the target userdata is still running", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: "Delete",
+      isManagedUserdataInUse: async () => true,
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.deletedPaths, []);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.equal(registry.userdatas.length, 2);
+    assert.deepEqual(harness.warnings, [
+      'Are you sure you want to delete userdata "Personal"? Close all windows using it first. This will move its settings and data files to the trash.',
+      DELETE_IN_USE_MESSAGE,
+    ]);
   });
 
   it("handles deletion failure gracefully, keeping the entry in the registry", async () => {
@@ -938,8 +987,8 @@ describe("activateUserdataSwitcher", () => {
     await harness.run(COMMAND_DELETE_USERDATA);
 
     assert.deepEqual(harness.warnings, [
-      'Are you sure you want to delete userdata "Personal"? This will move all its settings and data files to the trash.',
-      "Could not delete userdata folder. It might be open in another window. Please close all windows using this userdata and try again.",
+      'Are you sure you want to delete userdata "Personal"? Close all windows using it first. This will move its settings and data files to the trash.',
+      DELETE_TRASH_FAILURE_MESSAGE,
     ]);
     const registry = loadRegistry(registryPath(harness.storeRoot));
     assert.equal(registry.userdatas.length, 2);

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -5,8 +5,9 @@ import path from "node:path";
 import { after, describe, it } from "node:test";
 import {
   DELETE_BLOCKED_CURRENT_WINDOW_MESSAGE,
-  DELETE_IN_USE_MESSAGE,
   DELETE_NO_MANAGED_MESSAGE,
+  DELETE_QUIT_AND_DELETE_LABEL,
+  DELETE_QUIT_FAILED_MESSAGE,
   DELETE_TRASH_FAILURE_MESSAGE,
 } from "./deleteUserdata";
 import type { SupportedHostAdapter } from "./host";
@@ -108,7 +109,9 @@ function createTestHarness(input?: {
   mkdirSync?: UserdataSwitcherActivation["mkdirSync"];
   deletePathFailure?: boolean;
   warningMessageChoice?: string;
+  warningMessageChoices?: readonly string[];
   isManagedUserdataInUse?: UserdataSwitcherActivation["isManagedUserdataInUse"];
+  quitManagedUserdataInstance?: UserdataSwitcherActivation["quitManagedUserdataInstance"];
 }): TestHarness {
   const tempRoot = process.platform === "darwin" ? "/tmp" : os.tmpdir();
   const tempDir = fs.mkdtempSync(
@@ -147,6 +150,12 @@ function createTestHarness(input?: {
     ...(input?.inputBoxValues ??
       (input?.inputBoxValue !== undefined ? [input.inputBoxValue] : [])),
   ];
+  const warningMessageChoices = [
+    ...(input?.warningMessageChoices ??
+      (input?.warningMessageChoice !== undefined
+        ? [input.warningMessageChoice]
+        : [])),
+  ];
 
   const host: SupportedHostAdapter = {
     id: "cursor",
@@ -180,7 +189,8 @@ function createTestHarness(input?: {
     },
     showWarningMessage: async (message, ...items) => {
       warnings.push(message);
-      return input?.warningMessageChoice ?? items[0];
+      const choice = warningMessageChoices.shift();
+      return choice ?? items[0];
     },
     showInformationMessage: async (message) => {
       infos.push(message);
@@ -193,6 +203,9 @@ function createTestHarness(input?: {
         throw new Error("mock delete failure");
       }
       deletedPaths.push(fsPath);
+      if (fs.existsSync(fsPath)) {
+        fs.rmSync(fsPath, { recursive: true, force: true });
+      }
     },
   };
 
@@ -222,6 +235,7 @@ function createTestHarness(input?: {
         fs.mkdirSync(directory, options);
       }),
     isManagedUserdataInUse: input?.isManagedUserdataInUse,
+    quitManagedUserdataInstance: input?.quitManagedUserdataInstance,
   };
 
   return {
@@ -943,13 +957,13 @@ describe("activateUserdataSwitcher", () => {
     assert.deepEqual(harness.deletedPaths, []);
   });
 
-  it("blocks deletion when the target userdata is still running", async () => {
+  it("blocks deletion when the target userdata is still running and user cancels", async () => {
     const harness = createTestHarness({
       quickPickSelection: {
         label: "Personal",
         intent: { kind: "open", userdataId: "personal" },
       },
-      warningMessageChoice: "Delete",
+      warningMessageChoice: "Cancel",
       isManagedUserdataInUse: async () => true,
     });
     harnesses.push(harness);
@@ -963,10 +977,67 @@ describe("activateUserdataSwitcher", () => {
     assert.deepEqual(harness.deletedPaths, []);
     const registry = loadRegistry(registryPath(harness.storeRoot));
     assert.equal(registry.userdatas.length, 2);
-    assert.deepEqual(harness.warnings, [
-      'Are you sure you want to delete userdata "Personal"? Close all windows using it first. This will move its settings and data files to the trash.',
-      DELETE_IN_USE_MESSAGE,
+    assert.equal(harness.warnings.length, 1);
+    assert.match(harness.warnings[0], /still running/);
+    assert.match(harness.warnings[0], /Quit and delete/);
+  });
+
+  it("quits a running instance and deletes when the user confirms quit and delete", async () => {
+    let inUse = true;
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: DELETE_QUIT_AND_DELETE_LABEL,
+      isManagedUserdataInUse: async () => inUse,
+      quitManagedUserdataInstance: async () => {
+        inUse = false;
+        return true;
+      },
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.deletedPaths, [
+      path.join(harness.storeRoot, "u/personal"),
     ]);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.deepEqual(registry.userdatas, [
+      { id: "default", kind: "default", label: "Default" },
+    ]);
+    assert.deepEqual(harness.infos, ['Userdata "Personal" has been deleted.']);
+  });
+
+  it("shows quit failure when the running instance cannot be stopped", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: DELETE_QUIT_AND_DELETE_LABEL,
+      isManagedUserdataInUse: async () => true,
+      quitManagedUserdataInstance: async () => false,
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.deepEqual(harness.deletedPaths, []);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.equal(registry.userdatas.length, 2);
+    assert.equal(harness.warnings.length, 2);
+    assert.match(harness.warnings[0], /still running/);
+    assert.deepEqual(harness.warnings[1], DELETE_QUIT_FAILED_MESSAGE);
   });
 
   it("handles deletion failure gracefully, keeping the entry in the registry", async () => {
@@ -986,10 +1057,9 @@ describe("activateUserdataSwitcher", () => {
     activateUserdataSwitcher(harness.activation);
     await harness.run(COMMAND_DELETE_USERDATA);
 
-    assert.deepEqual(harness.warnings, [
-      'Are you sure you want to delete userdata "Personal"? Close all windows using it first. This will move its settings and data files to the trash.',
-      DELETE_TRASH_FAILURE_MESSAGE,
-    ]);
+    assert.equal(harness.warnings.length, 2);
+    assert.match(harness.warnings[0], /Delete userdata "Personal"/);
+    assert.deepEqual(harness.warnings[1], DELETE_TRASH_FAILURE_MESSAGE);
     const registry = loadRegistry(registryPath(harness.storeRoot));
     assert.equal(registry.userdatas.length, 2);
     assert.ok(registry.userdatas.some((entry) => entry.id === "personal"));

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -9,6 +9,8 @@ import {
   DELETE_QUIT_AND_DELETE_LABEL,
   DELETE_QUIT_FAILED_MESSAGE,
   DELETE_TRASH_FAILURE_MESSAGE,
+  DELETE_VERIFY_INSTANCE_STILL_RUNNING_MESSAGE,
+  DELETE_VERIFY_PATH_STILL_EXISTS_MESSAGE,
 } from "./deleteUserdata";
 import type { SupportedHostAdapter } from "./host";
 import type { LaunchCommand, LaunchEditor } from "./launcher";
@@ -108,6 +110,7 @@ function createTestHarness(input?: {
   launchEditorImpl?: LaunchEditor;
   mkdirSync?: UserdataSwitcherActivation["mkdirSync"];
   deletePathFailure?: boolean;
+  deletePathSkipRemoval?: boolean;
   warningMessageChoice?: string;
   warningMessageChoices?: readonly string[];
   isManagedUserdataInUse?: UserdataSwitcherActivation["isManagedUserdataInUse"];
@@ -203,7 +206,7 @@ function createTestHarness(input?: {
         throw new Error("mock delete failure");
       }
       deletedPaths.push(fsPath);
-      if (fs.existsSync(fsPath)) {
+      if (!input?.deletePathSkipRemoval && fs.existsSync(fsPath)) {
         fs.rmSync(fsPath, { recursive: true, force: true });
       }
     },
@@ -957,7 +960,7 @@ describe("activateUserdataSwitcher", () => {
     assert.deepEqual(harness.deletedPaths, []);
   });
 
-  it("blocks deletion when the target userdata is still running and user cancels", async () => {
+  it("cancels deletion when the user dismisses the running-instance confirmation", async () => {
     const harness = createTestHarness({
       quickPickSelection: {
         label: "Personal",
@@ -1060,6 +1063,68 @@ describe("activateUserdataSwitcher", () => {
     assert.equal(harness.warnings.length, 2);
     assert.match(harness.warnings[0], /Delete userdata "Personal"/);
     assert.deepEqual(harness.warnings[1], DELETE_TRASH_FAILURE_MESSAGE);
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.equal(registry.userdatas.length, 2);
+    assert.ok(registry.userdatas.some((entry) => entry.id === "personal"));
+  });
+
+  it("keeps the registry entry when the folder still exists after delete", async () => {
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: "Delete",
+      deletePathSkipRemoval: true,
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(path.join(harness.storeRoot, "u/personal"), {
+      recursive: true,
+    });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.equal(harness.warnings.length, 2);
+    assert.match(harness.warnings[0], /Delete userdata "Personal"/);
+    assert.deepEqual(
+      harness.warnings[1],
+      DELETE_VERIFY_PATH_STILL_EXISTS_MESSAGE,
+    );
+    const registry = loadRegistry(registryPath(harness.storeRoot));
+    assert.equal(registry.userdatas.length, 2);
+    assert.ok(registry.userdatas.some((entry) => entry.id === "personal"));
+  });
+
+  it("keeps the registry entry when the instance is still running after delete", async () => {
+    let probeCount = 0;
+    const harness = createTestHarness({
+      quickPickSelection: {
+        label: "Personal",
+        intent: { kind: "open", userdataId: "personal" },
+      },
+      warningMessageChoice: DELETE_QUIT_AND_DELETE_LABEL,
+      isManagedUserdataInUse: async () => {
+        probeCount += 1;
+        return probeCount === 1 || probeCount === 4;
+      },
+    });
+    harnesses.push(harness);
+
+    fs.mkdirSync(harness.storeRoot, { recursive: true });
+    savePersonalRegistry(harness.storeRoot);
+
+    activateUserdataSwitcher(harness.activation);
+    await harness.run(COMMAND_DELETE_USERDATA);
+
+    assert.equal(harness.warnings.length, 2);
+    assert.match(harness.warnings[0], /still running/);
+    assert.deepEqual(
+      harness.warnings[1],
+      DELETE_VERIFY_INSTANCE_STILL_RUNNING_MESSAGE,
+    );
     const registry = loadRegistry(registryPath(harness.storeRoot));
     assert.equal(registry.userdatas.length, 2);
     assert.ok(registry.userdatas.some((entry) => entry.id === "personal"));

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -58,17 +58,8 @@ interface TestHarness {
   run(command: string): Promise<unknown>;
 }
 
-const START_FROM_CURRENT_SETTINGS_PICK: QuickPickItem = {
-  label: "Start from current settings",
-  description: "Recommended",
-  creationMode: "seedCurrent",
-};
-
-const START_EMPTY_PICK: QuickPickItem = {
-  label: "Start empty",
-  description: "Fresh editor defaults",
-  creationMode: "empty",
-};
+const START_FROM_CURRENT_SETTINGS_LABEL = "Start from current settings";
+const START_EMPTY_LABEL = "Start empty";
 
 function globalStoragePathFor(userdataRoot: string): string {
   return path.join(
@@ -113,6 +104,8 @@ function createTestHarness(input?: {
   deletePathSkipRemoval?: boolean;
   warningMessageChoice?: string;
   warningMessageChoices?: readonly string[];
+  informationMessageChoice?: string;
+  informationMessageChoices?: readonly string[];
   isManagedUserdataInUse?: UserdataSwitcherActivation["isManagedUserdataInUse"];
   quitManagedUserdataInstance?: UserdataSwitcherActivation["quitManagedUserdataInstance"];
 }): TestHarness {
@@ -159,6 +152,12 @@ function createTestHarness(input?: {
         ? [input.warningMessageChoice]
         : [])),
   ];
+  const informationMessageChoices = [
+    ...(input?.informationMessageChoices ??
+      (input?.informationMessageChoice !== undefined
+        ? [input.informationMessageChoice]
+        : [])),
+  ];
 
   const host: SupportedHostAdapter = {
     id: "cursor",
@@ -195,8 +194,11 @@ function createTestHarness(input?: {
       const choice = warningMessageChoices.shift();
       return choice ?? items[0];
     },
-    showInformationMessage: async (message) => {
+    showInformationMessage: async (message, ...items) => {
+      uiEvents.push("informationMessage");
       infos.push(message);
+      const choice = informationMessageChoices.shift();
+      return choice ?? items[0];
     },
     revealPathInOs: async (fsPath) => {
       revealedPaths.push(fsPath);
@@ -351,13 +353,13 @@ describe("activateUserdataSwitcher", () => {
   it("launches the selected managed userdata from the open menu", async () => {
     const harness = createTestHarness({
       quickPickSelections: [
-        START_FROM_CURRENT_SETTINGS_PICK,
         {
           label: "Personal",
           intent: { kind: "open", userdataId: "personal" },
         },
       ],
       inputBoxValue: "Personal",
+      informationMessageChoice: START_FROM_CURRENT_SETTINGS_LABEL,
     });
     harnesses.push(harness);
 
@@ -406,9 +408,9 @@ describe("activateUserdataSwitcher", () => {
           label: CREATE_USERDATA_LABEL,
           intent: { kind: "create" },
         },
-        START_FROM_CURRENT_SETTINGS_PICK,
       ],
       inputBoxValue: "Work",
+      informationMessageChoice: START_FROM_CURRENT_SETTINGS_LABEL,
     });
     harnesses.push(harness);
 
@@ -426,8 +428,8 @@ describe("activateUserdataSwitcher", () => {
 
   it("passes intent metadata through the open menu items", async () => {
     const harness = createTestHarness({
-      quickPickSelection: START_FROM_CURRENT_SETTINGS_PICK,
       inputBoxValue: "Personal",
+      informationMessageChoice: START_FROM_CURRENT_SETTINGS_LABEL,
     });
     harnesses.push(harness);
 
@@ -435,7 +437,7 @@ describe("activateUserdataSwitcher", () => {
     await harness.run(COMMAND_CREATE_USERDATA);
     await harness.run(COMMAND_OPEN_WITH_USERDATA);
 
-    assert.deepEqual(harness.quickPickItems[1], [
+    assert.deepEqual(harness.quickPickItems[0], [
       {
         label: "Personal",
         description: "Managed Userdata",
@@ -467,8 +469,8 @@ describe("activateUserdataSwitcher", () => {
 
   it("creates managed userdata, persists the registry, and launches it", async () => {
     const harness = createTestHarness({
-      quickPickSelection: START_FROM_CURRENT_SETTINGS_PICK,
       inputBoxValue: "Personal",
+      informationMessageChoice: START_FROM_CURRENT_SETTINGS_LABEL,
     });
     harnesses.push(harness);
 
@@ -493,27 +495,28 @@ describe("activateUserdataSwitcher", () => {
     ]);
   });
 
-  it("prompts for creation mode before the userdata label", async () => {
+  it("prompts for the userdata label before the creation mode", async () => {
     const harness = createTestHarness({
-      quickPickSelection: START_FROM_CURRENT_SETTINGS_PICK,
       inputBoxValue: "Personal",
+      informationMessageChoice: START_FROM_CURRENT_SETTINGS_LABEL,
     });
     harnesses.push(harness);
 
     activateUserdataSwitcher(harness.activation);
     await harness.run(COMMAND_CREATE_USERDATA);
 
-    assert.deepEqual(harness.quickPickItems[0], [
-      START_FROM_CURRENT_SETTINGS_PICK,
-      START_EMPTY_PICK,
+    assert.deepEqual(harness.uiEvents.slice(0, 2), [
+      "inputBox",
+      "informationMessage",
     ]);
-    assert.deepEqual(harness.uiEvents.slice(0, 2), ["quickPick", "inputBox"]);
+    assert.equal(harness.infos[0], 'How should "Personal" be initialized?');
+    assert.equal(harness.quickPickItems.length, 0);
   });
 
   it("seeds new userdata from current settings without copying identity state", async () => {
     const harness = createTestHarness({
-      quickPickSelection: START_FROM_CURRENT_SETTINGS_PICK,
       inputBoxValue: "Personal",
+      informationMessageChoice: START_FROM_CURRENT_SETTINGS_LABEL,
     });
     harnesses.push(harness);
     const currentUserDir = path.join(harness.defaultUserdataRoot, "User");
@@ -600,8 +603,8 @@ describe("activateUserdataSwitcher", () => {
   it("seeds from the current managed userdata when that window creates another", async () => {
     const sourceManagedDir = "u/personal";
     const harness = createTestHarness({
-      quickPickSelection: START_FROM_CURRENT_SETTINGS_PICK,
       inputBoxValue: "Client",
+      informationMessageChoice: START_FROM_CURRENT_SETTINGS_LABEL,
     });
     harnesses.push(harness);
     harness.activation.globalStoragePath = globalStoragePathFor(
@@ -644,8 +647,8 @@ describe("activateUserdataSwitcher", () => {
 
   it("starts empty when creating userdata with fresh editor defaults", async () => {
     const harness = createTestHarness({
-      quickPickSelection: START_EMPTY_PICK,
       inputBoxValue: "Personal",
+      informationMessageChoice: START_EMPTY_LABEL,
     });
     harnesses.push(harness);
     const currentUserDir = path.join(harness.defaultUserdataRoot, "User");
@@ -667,8 +670,8 @@ describe("activateUserdataSwitcher", () => {
 
   it("does not persist a managed userdata when directory creation fails", async () => {
     const harness = createTestHarness({
-      quickPickSelection: START_FROM_CURRENT_SETTINGS_PICK,
       inputBoxValue: "Personal",
+      informationMessageChoice: START_FROM_CURRENT_SETTINGS_LABEL,
       mkdirSync: () => {
         throw new Error("mkdir failed");
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,8 +65,14 @@ export function createVscodeUi(logger: LaunchLogger): UserdataSwitcherUi {
     showErrorMessage: (message) => vscode.window.showErrorMessage(message),
     showWarningMessage: (message, ...items) =>
       vscode.window.showWarningMessage(message, ...items),
-    showInformationMessage: (message) =>
-      vscode.window.showInformationMessage(message),
+    showInformationMessage: (message, ...items) =>
+      items.length > 0
+        ? vscode.window.showInformationMessage(
+            message,
+            { modal: true },
+            ...items,
+          )
+        : vscode.window.showInformationMessage(message),
     revealPathInOs: async (fsPath) => {
       const uri = vscode.Uri.file(fsPath);
       logger.info(`revealFileInOS input.fsPath=${JSON.stringify(fsPath)}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ export function activate(context: vscode.ExtensionContext): void {
     globalStoragePath: context.globalStorageUri.fsPath,
     appRoot: vscode.env.appRoot,
     workspace: vscode.workspace,
+    editorVersion: vscode.version,
     subscribe: (disposable) => {
       context.subscriptions.push(disposable);
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,8 @@ export function createVscodeUi(logger: LaunchLogger): UserdataSwitcherUi {
       ) as PromiseLike<QuickPickItem | undefined>,
     showInputBox: (options) => vscode.window.showInputBox(options),
     showErrorMessage: (message) => vscode.window.showErrorMessage(message),
-    showWarningMessage: (message) => vscode.window.showWarningMessage(message),
+    showWarningMessage: (message, ...items) =>
+      vscode.window.showWarningMessage(message, ...items),
     showInformationMessage: (message) =>
       vscode.window.showInformationMessage(message),
     revealPathInOs: async (fsPath) => {
@@ -78,6 +79,16 @@ export function createVscodeUi(logger: LaunchLogger): UserdataSwitcherUi {
         logger.error(`revealFileInOS failed: ${message}`);
         throw error;
       }
+    },
+    deletePath: async (fsPath, options) => {
+      const uri = vscode.Uri.file(fsPath);
+      logger.info(
+        `deletePath fsPath=${JSON.stringify(fsPath)} useTrash=${options.useTrash}`,
+      );
+      await vscode.workspace.fs.delete(uri, {
+        recursive: true,
+        useTrash: options.useTrash,
+      });
     },
   };
 }

--- a/src/launcher.test.ts
+++ b/src/launcher.test.ts
@@ -332,17 +332,18 @@ describe("launchEditor", () => {
 
   it("spawns the editor CLI with sanitized VS Code process environment", async () => {
     let unrefCalled = false;
-    let spawnOptions: { env: NodeJS.ProcessEnv } | undefined;
+    let spawnOptions:
+      | {
+          env: NodeJS.ProcessEnv;
+          stdio: ["ignore", "ignore", "ignore"];
+        }
+      | undefined;
     const { logs, logger } = createTestLogger();
-    const stdout = new EventEmitter();
-    const stderr = new EventEmitter();
     const child = new EventEmitter() as EventEmitter & {
-      stderr: EventEmitter;
-      stdout: EventEmitter;
+      pid: number;
       unref(): void;
     };
-    child.stdout = stdout;
-    child.stderr = stderr;
+    child.pid = 4321;
     child.unref = () => {
       unrefCalled = true;
     };
@@ -367,25 +368,17 @@ describe("launchEditor", () => {
     );
 
     child.emit("spawn");
-    stdout.emit("data", "hello\n");
-    stderr.emit("data", Buffer.from("warning\n"));
-    child.emit("exit", 0, null);
-    child.emit("close", 0, null);
-
     await launched;
 
     assert.equal(unrefCalled, true);
+    assert.deepEqual(spawnOptions?.stdio, ["ignore", "ignore", "ignore"]);
     assert.equal(spawnOptions?.env.ELECTRON_RUN_AS_NODE, undefined);
     assert.equal(spawnOptions?.env.VSCODE_IPC_HOOK_CLI, undefined);
     assert.equal(spawnOptions?.env.PATH, "/usr/bin");
     assert.equal(spawnOptions?.env.VSCODE_PORTABLE, "/portable");
     assert.deepEqual(logs, [
       "info:Launch environment sanitized; removed ELECTRON_RUN_AS_NODE, VSCODE_IPC_HOOK_CLI",
-      "info:Editor CLI spawned successfully",
-      "info:Editor CLI stdout: hello",
-      "info:Editor CLI stderr: warning",
-      "info:Editor CLI exit event: code=0 signal=null",
-      "info:Editor CLI close event: code=0 signal=null",
+      "info:Editor CLI spawned successfully (pid=4321)",
     ]);
   });
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,10 +1,10 @@
 import { spawn } from "node:child_process";
+import { VSCODE_MAIN_SOCKET_BASENAME } from "./editorIpc";
 import type { SupportedHostAdapter } from "./host";
 import { resolveManagedDataDir } from "./paths";
 import type { UserdataEntry } from "./registry";
 
 const MACOS_UNIX_SOCKET_PATH_LIMIT = 103;
-const VSCODE_MAIN_SOCKET_BASENAME = "1.12-main.sock";
 
 interface WorkspaceUri {
   fsPath: string;

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
-import { VSCODE_MAIN_SOCKET_BASENAME } from "./editorIpc";
+import {
+  listMainSocketPaths,
+  mainSocketBasenameForEditorVersion,
+} from "./editorIpc";
 import type { SupportedHostAdapter } from "./host";
 import { resolveManagedDataDir } from "./paths";
 import type { UserdataEntry } from "./registry";
@@ -127,6 +130,7 @@ export function buildOpenWithUserdataCommand(input: {
   appRoot: string;
   storeRoot: string;
   workspace: WorkspaceShape;
+  editorVersion?: string;
   logger?: LaunchLogger;
 }): LaunchCommand {
   const editorCli = input.host.discoverEditorCli(input.appRoot, {
@@ -155,6 +159,7 @@ export function buildOpenWithUserdataCommand(input: {
 function validateManagedUserdataSocketPath(input: {
   entry: UserdataEntry;
   host: SupportedHostAdapter;
+  editorVersion?: string;
   logger?: LaunchLogger;
   storeRoot: string;
 }): void {
@@ -166,10 +171,16 @@ function validateManagedUserdataSocketPath(input: {
     return;
   }
 
-  const socketPath = `${resolveManagedDataDir(
+  const managedDataDir = resolveManagedDataDir(
     input.storeRoot,
     input.entry.relativeDataDir,
-  )}/${VSCODE_MAIN_SOCKET_BASENAME}`;
+  );
+  const socketPaths = listMainSocketPaths(managedDataDir, input.editorVersion);
+  const socketPath =
+    socketPaths[0] ??
+    `${managedDataDir}/${mainSocketBasenameForEditorVersion(
+      input.editorVersion ?? "1.12.0",
+    )}`;
   input.logger?.info(
     `macOS socket path length=${socketPath.length}/${MACOS_UNIX_SOCKET_PATH_LIMIT}: ${socketPath}`,
   );
@@ -186,6 +197,7 @@ export async function openWithUserdata(input: {
   appRoot: string;
   storeRoot: string;
   workspace: WorkspaceShape;
+  editorVersion?: string;
   logger?: LaunchLogger;
   launchEditorImpl?: LaunchEditor;
 }): Promise<void> {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -41,17 +41,8 @@ export type LaunchEditor = (
 ) => Promise<void>;
 
 interface SpawnedEditorProcess {
-  stderr?: { on(event: "data", listener: (data: unknown) => void): void };
-  stdout?: { on(event: "data", listener: (data: unknown) => void): void };
-  once(
-    event: "close",
-    listener: (code: number | null, signal: string | null) => void,
-  ): this;
+  pid?: number;
   once(event: "error", listener: (error: Error) => void): this;
-  once(
-    event: "exit",
-    listener: (code: number | null, signal: string | null) => void,
-  ): this;
   once(event: "spawn", listener: () => void): this;
   unref(): void;
 }
@@ -65,7 +56,7 @@ interface LaunchDeps {
     options: {
       detached: true;
       env: NodeJS.ProcessEnv;
-      stdio: ["ignore", "pipe", "pipe"];
+      stdio: ["ignore", "ignore", "ignore"];
     },
   ): SpawnedEditorProcess;
 }
@@ -251,29 +242,12 @@ export function launchEditor(
       child = deps.spawn(spawnCommand.command, spawnCommand.args, {
         detached: true,
         env,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "ignore", "ignore"],
       });
     } catch (error) {
       reject(error);
       return;
     }
-
-    child.stdout?.on("data", (data) => {
-      logProcessOutput(logger, "stdout", data);
-    });
-    child.stderr?.on("data", (data) => {
-      logProcessOutput(logger, "stderr", data);
-    });
-    child.once("exit", (code, signal) => {
-      logger?.info(
-        `Editor CLI exit event: code=${formatExitValue(code)} signal=${formatExitValue(signal)}`,
-      );
-    });
-    child.once("close", (code, signal) => {
-      logger?.info(
-        `Editor CLI close event: code=${formatExitValue(code)} signal=${formatExitValue(signal)}`,
-      );
-    });
 
     let settled = false;
     child.once("error", (error) => {
@@ -287,7 +261,8 @@ export function launchEditor(
       if (!settled) {
         settled = true;
         child.unref();
-        logger?.info("Editor CLI spawned successfully");
+        const pid = typeof child.pid === "number" ? ` (pid=${child.pid})` : "";
+        logger?.info(`Editor CLI spawned successfully${pid}`);
         resolve();
       }
     });
@@ -339,21 +314,4 @@ function resolveSpawnCommand(
 
 function isWindowsCommandShim(command: string): boolean {
   return /\.(?:bat|cmd)$/i.test(command);
-}
-
-function logProcessOutput(
-  logger: LaunchLogger | undefined,
-  stream: "stderr" | "stdout",
-  data: unknown,
-): void {
-  const output = Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
-  for (const line of output.split(/\r?\n/)) {
-    if (line.trim()) {
-      logger?.info(`Editor CLI ${stream}: ${line}`);
-    }
-  }
-}
-
-function formatExitValue(value: number | string | null): string {
-  return value === null ? "null" : String(value);
 }

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import {
   COMMAND_CREATE_USERDATA,
+  COMMAND_DELETE_USERDATA,
   COMMAND_OPEN_WITH_USERDATA,
   COMMAND_RENAME_CURRENT_USERDATA,
   COMMAND_REVEAL_CURRENT_USERDATA,
@@ -61,6 +62,7 @@ describe("extension manifest", () => {
         COMMAND_RENAME_CURRENT_USERDATA,
         COMMAND_SHOW_CURRENT_USERDATA,
         COMMAND_REVEAL_CURRENT_USERDATA,
+        COMMAND_DELETE_USERDATA,
       ],
     );
     assert.ok(

--- a/src/menu.test.ts
+++ b/src/menu.test.ts
@@ -4,6 +4,7 @@ import {
   ACTIONS_SEPARATOR_LABEL,
   buildOpenWithUserdataMenuItems,
   CREATE_USERDATA_LABEL,
+  DELETE_USERDATA_LABEL,
   RENAME_CURRENT_USERDATA_LABEL,
   REVEAL_CURRENT_USERDATA_LABEL,
   resolveOpenWithUserdataMenuIntent,
@@ -39,7 +40,7 @@ describe("buildOpenWithUserdataMenuItems", () => {
     });
     assert.deepEqual(
       items.map((item) => item.kind ?? "item"),
-      ["separator", "item", "item", "item"],
+      ["separator", "item", "item", "item", "item"],
     );
     assert.equal(items[0]?.label, "Actions");
     assert.equal(items[1]?.label, RENAME_CURRENT_USERDATA_LABEL);
@@ -48,6 +49,8 @@ describe("buildOpenWithUserdataMenuItems", () => {
     assert.deepEqual(items[2]?.intent, { kind: "reveal" });
     assert.equal(items[3]?.label, CREATE_USERDATA_LABEL);
     assert.deepEqual(items[3]?.intent, { kind: "create" });
+    assert.equal(items[4]?.label, DELETE_USERDATA_LABEL);
+    assert.deepEqual(items[4]?.intent, { kind: "delete" });
   });
 
   it("omits rename when the current userdata is unknown", () => {
@@ -56,13 +59,15 @@ describe("buildOpenWithUserdataMenuItems", () => {
     });
     assert.deepEqual(
       items.map((item) => item.kind ?? "item"),
-      ["item", "item", "separator", "item", "item"],
+      ["item", "item", "separator", "item", "item", "item"],
     );
-    assert.equal(items.at(-1)?.label, CREATE_USERDATA_LABEL);
-    assert.equal(items.at(-2)?.label, REVEAL_CURRENT_USERDATA_LABEL);
-    assert.equal(items.at(-3)?.label, "Actions");
-    assert.deepEqual(items.at(-1)?.intent, { kind: "create" });
-    assert.deepEqual(items.at(-2)?.intent, { kind: "reveal" });
+    assert.equal(items.at(-1)?.label, DELETE_USERDATA_LABEL);
+    assert.equal(items.at(-2)?.label, CREATE_USERDATA_LABEL);
+    assert.equal(items.at(-3)?.label, REVEAL_CURRENT_USERDATA_LABEL);
+    assert.equal(items.at(-4)?.label, "Actions");
+    assert.deepEqual(items.at(-1)?.intent, { kind: "delete" });
+    assert.deepEqual(items.at(-2)?.intent, { kind: "create" });
+    assert.deepEqual(items.at(-3)?.intent, { kind: "reveal" });
     assert.ok(items.every((item) => item.intent?.kind !== "rename"));
   });
 
@@ -89,14 +94,16 @@ describe("buildOpenWithUserdataMenuItems", () => {
     );
     assert.deepEqual(
       items.map((item) => item.kind ?? "item"),
-      ["item", "item", "separator", "item", "item", "item"],
+      ["item", "item", "separator", "item", "item", "item", "item"],
     );
-    assert.equal(items.at(-3)?.label, RENAME_CURRENT_USERDATA_LABEL);
-    assert.deepEqual(items.at(-3)?.intent, { kind: "rename" });
-    assert.equal(items.at(-2)?.label, REVEAL_CURRENT_USERDATA_LABEL);
-    assert.deepEqual(items.at(-2)?.intent, { kind: "reveal" });
-    assert.equal(items.at(-1)?.label, CREATE_USERDATA_LABEL);
-    assert.deepEqual(items.at(-1)?.intent, { kind: "create" });
+    assert.equal(items.at(-4)?.label, RENAME_CURRENT_USERDATA_LABEL);
+    assert.deepEqual(items.at(-4)?.intent, { kind: "rename" });
+    assert.equal(items.at(-3)?.label, REVEAL_CURRENT_USERDATA_LABEL);
+    assert.deepEqual(items.at(-3)?.intent, { kind: "reveal" });
+    assert.equal(items.at(-2)?.label, CREATE_USERDATA_LABEL);
+    assert.deepEqual(items.at(-2)?.intent, { kind: "create" });
+    assert.equal(items.at(-1)?.label, DELETE_USERDATA_LABEL);
+    assert.deepEqual(items.at(-1)?.intent, { kind: "delete" });
   });
 
   it("marks action CTAs with structured action data instead of relying on labels", () => {
@@ -120,9 +127,10 @@ describe("buildOpenWithUserdataMenuItems", () => {
     );
 
     const managedItem = items[0];
-    const renameItem = items.at(-3);
-    const revealItem = items.at(-2);
-    const createItem = items.at(-1);
+    const renameItem = items.at(-4);
+    const revealItem = items.at(-3);
+    const createItem = items.at(-2);
+    const deleteItem = items.at(-1);
 
     assert.equal(managedItem?.label, CREATE_USERDATA_LABEL);
     assert.deepEqual(managedItem?.intent, {
@@ -135,6 +143,8 @@ describe("buildOpenWithUserdataMenuItems", () => {
     assert.deepEqual(revealItem?.intent, { kind: "reveal" });
     assert.equal(createItem?.label, CREATE_USERDATA_LABEL);
     assert.deepEqual(createItem?.intent, { kind: "create" });
+    assert.equal(deleteItem?.label, DELETE_USERDATA_LABEL);
+    assert.deepEqual(deleteItem?.intent, { kind: "delete" });
   });
 });
 
@@ -178,11 +188,17 @@ describe("resolveOpenWithUserdataMenuIntent", () => {
     assert.deepEqual(
       resolveOpenWithUserdataMenuIntent(registry, items.at(-1)),
       {
-        kind: "create",
+        kind: "delete",
       },
     );
     assert.deepEqual(
       resolveOpenWithUserdataMenuIntent(registry, items.at(-2)),
+      {
+        kind: "create",
+      },
+    );
+    assert.deepEqual(
+      resolveOpenWithUserdataMenuIntent(registry, items.at(-3)),
       {
         kind: "reveal",
       },

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -8,12 +8,14 @@ export const RENAME_CURRENT_USERDATA_LABEL =
   "$(edit) Rename Current Userdata...";
 export const REVEAL_CURRENT_USERDATA_LABEL =
   "$(folder-opened) Reveal Current Userdata...";
+export const DELETE_USERDATA_LABEL = "$(trash) Delete Userdata...";
 
 type MenuItemKind = "item" | "separator";
 export type UserdataMenuItemIntent =
   | { kind: "create" }
   | { kind: "rename" }
   | { kind: "reveal" }
+  | { kind: "delete" }
   | { kind: "open"; userdataId: string };
 
 export type UserdataMenuIntent =
@@ -21,6 +23,7 @@ export type UserdataMenuIntent =
   | { kind: "create" }
   | { kind: "rename" }
   | { kind: "reveal" }
+  | { kind: "delete" }
   | { kind: "open"; entry: UserdataEntry };
 
 export interface UserdataMenuSelection {
@@ -66,6 +69,11 @@ export function buildOpenWithUserdataMenuItems(
       label: CREATE_USERDATA_LABEL,
       alwaysShow: true,
     },
+    {
+      intent: { kind: "delete" },
+      label: DELETE_USERDATA_LABEL,
+      alwaysShow: true,
+    },
   ];
 
   return [
@@ -88,6 +96,7 @@ export function resolveOpenWithUserdataMenuIntent(
     case "create":
     case "rename":
     case "reveal":
+    case "delete":
       return intent;
     case "open": {
       const entry = registry.userdatas.find(

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -109,4 +109,15 @@ describe("registry", () => {
     assert.equal(updated.userdatas.length, 1);
     assert.equal(updated.userdatas[0]?.id, "default");
   });
+
+  it("does not remove the default userdata entry", () => {
+    const registry = {
+      version: 1 as const,
+      userdatas: [
+        { id: "default", kind: "default" as const, label: "Default" },
+      ],
+    };
+    const updated = removeUserdata(registry, "default");
+    assert.deepEqual(updated, registry);
+  });
 });

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -7,6 +7,7 @@ import {
   addManagedUserdata,
   ensureDefaultUserdata,
   loadRegistry,
+  removeUserdata,
   renameUserdata,
 } from "./registry";
 
@@ -88,6 +89,24 @@ describe("registry", () => {
     };
     const updated = renameUserdata(registry, "default", "Work");
     assert.equal(updated.userdatas[0]?.label, "Work");
+    assert.equal(updated.userdatas[0]?.id, "default");
+  });
+
+  it("removes a userdata by its ID", () => {
+    const registry = {
+      version: 1 as const,
+      userdatas: [
+        { id: "default", kind: "default" as const, label: "Default" },
+        {
+          id: "personal",
+          kind: "managed" as const,
+          label: "Personal",
+          relativeDataDir: "u/personal",
+        },
+      ],
+    };
+    const updated = removeUserdata(registry, "personal");
+    assert.equal(updated.userdatas.length, 1);
     assert.equal(updated.userdatas[0]?.id, "default");
   });
 });

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -104,9 +104,17 @@ export function renameUserdata(
 }
 
 export function removeUserdata(registry: Registry, entryId: string): Registry {
+  const entry = registry.userdatas.find(
+    (candidate) => candidate.id === entryId,
+  );
+  if (!entry || entry.kind === "default") {
+    return registry;
+  }
   return {
     version: 1,
-    userdatas: registry.userdatas.filter((entry) => entry.id !== entryId),
+    userdatas: registry.userdatas.filter(
+      (candidate) => candidate.id !== entryId,
+    ),
   };
 }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -103,6 +103,13 @@ export function renameUserdata(
   };
 }
 
+export function removeUserdata(registry: Registry, entryId: string): Registry {
+  return {
+    version: 1,
+    userdatas: registry.userdatas.filter((entry) => entry.id !== entryId),
+  };
+}
+
 const NON_ALPHANUMERIC_REGEX = /[^a-z0-9]+/g;
 const LEADING_TRAILING_HYPHENS_REGEX = /^-+|-+$/g;
 const TRAILING_HYPHENS_REGEX = /-+$/g;

--- a/src/runningEditorInstance.test.ts
+++ b/src/runningEditorInstance.test.ts
@@ -24,6 +24,24 @@ describe("commandLineUsesUserdataRoot", () => {
       ),
     );
   });
+
+  it("does not match a longer userdata root that merely shares a prefix", () => {
+    const userdataRoot = "/store/u/work";
+    const otherRoot = "/store/u/work-2";
+    assert.ok(
+      commandLineUsesUserdataRoot(
+        `4323 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=${otherRoot}`,
+        otherRoot,
+      ),
+    );
+    assert.equal(
+      commandLineUsesUserdataRoot(
+        `4323 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=${otherRoot}`,
+        userdataRoot,
+      ),
+      false,
+    );
+  });
 });
 
 describe("isMainEditorProcess", () => {
@@ -52,6 +70,7 @@ describe("listMainProcessIdsForUserdataRoot", () => {
           `4321 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=${userdataRoot}`,
           `4322 /Applications/Cursor.app/Contents/Frameworks/Cursor Helper (GPU) --user-data-dir=${userdataRoot}`,
           `4323 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=/store/u/work`,
+          `4324 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=/store/u/personal-backup`,
         ],
       }),
       [4321],

--- a/src/runningEditorInstance.test.ts
+++ b/src/runningEditorInstance.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  commandLineUsesUserdataRoot,
+  isMainEditorProcess,
+  listMainProcessIdsForUserdataRoot,
+  quitUserdataEditorInstance,
+} from "./runningEditorInstance";
+
+describe("commandLineUsesUserdataRoot", () => {
+  it("matches equals and spaced --user-data-dir forms", () => {
+    const userdataRoot =
+      "/Users/alice/Library/Application Support/udsw/cursor/u/personal";
+    assert.ok(
+      commandLineUsesUserdataRoot(
+        `/Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=${userdataRoot}`,
+        userdataRoot,
+      ),
+    );
+    assert.ok(
+      commandLineUsesUserdataRoot(
+        `/Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir ${userdataRoot}`,
+        userdataRoot,
+      ),
+    );
+  });
+});
+
+describe("isMainEditorProcess", () => {
+  it("ignores helper processes that share the userdata directory", () => {
+    assert.equal(
+      isMainEditorProcess(
+        "1234 /Applications/Cursor.app/Contents/Frameworks/Cursor Helper (GPU)",
+      ),
+      false,
+    );
+    assert.equal(
+      isMainEditorProcess(
+        "1234 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=/tmp/personal",
+      ),
+      true,
+    );
+  });
+});
+
+describe("listMainProcessIdsForUserdataRoot", () => {
+  it("returns only main editor process ids for the target userdata root", () => {
+    const userdataRoot = "/store/u/personal";
+    assert.deepEqual(
+      listMainProcessIdsForUserdataRoot(userdataRoot, {
+        listProcessLines: () => [
+          `4321 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=${userdataRoot}`,
+          `4322 /Applications/Cursor.app/Contents/Frameworks/Cursor Helper (GPU) --user-data-dir=${userdataRoot}`,
+          `4323 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=/store/u/work`,
+        ],
+      }),
+      [4321],
+    );
+  });
+});
+
+describe("quitUserdataEditorInstance", () => {
+  it("terminates matching processes and waits until the IPC socket is gone", async () => {
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let probeCount = 0;
+
+    const quit = await quitUserdataEditorInstance("/store/u/personal", {
+      platform: "darwin",
+      listProcessLines: () => [
+        "4321 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=/store/u/personal",
+      ],
+      killProcess: (pid, signal) => {
+        killed.push({ pid, signal });
+      },
+      connect: async () => {
+        probeCount += 1;
+        return probeCount < 2 ? "connected" : "refused";
+      },
+      sleep: async () => {},
+      waitTimeoutMs: 1_000,
+    });
+
+    assert.equal(quit, true);
+    assert.deepEqual(killed, [{ pid: 4321, signal: "SIGTERM" }]);
+  });
+
+  it("escalates to SIGKILL when SIGTERM does not stop the instance", async () => {
+    const signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let probeCount = 0;
+
+    const quit = await quitUserdataEditorInstance("/store/u/personal", {
+      platform: "darwin",
+      listProcessLines: () => [
+        "4321 /Applications/Cursor.app/Contents/MacOS/Cursor --user-data-dir=/store/u/personal",
+      ],
+      killProcess: (pid, signal) => {
+        signals.push({ pid, signal });
+      },
+      connect: async () => {
+        probeCount += 1;
+        return probeCount < 2 ? "connected" : "refused";
+      },
+      sleep: async () => {},
+      waitTimeoutMs: 0,
+    });
+
+    assert.equal(quit, true);
+    assert.deepEqual(signals, [
+      { pid: 4321, signal: "SIGTERM" },
+      { pid: 4321, signal: "SIGKILL" },
+    ]);
+  });
+});

--- a/src/runningEditorInstance.test.ts
+++ b/src/runningEditorInstance.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   commandLineUsesUserdataRoot,
   isMainEditorProcess,
+  isUserdataEditorInstanceRunning,
   listMainProcessIdsForUserdataRoot,
   quitUserdataEditorInstance,
 } from "./runningEditorInstance";
@@ -40,6 +41,23 @@ describe("commandLineUsesUserdataRoot", () => {
         userdataRoot,
       ),
       false,
+    );
+  });
+
+  it("matches quoted Windows --user-data-dir values case-insensitively", () => {
+    const userdataRoot =
+      "C:\\Users\\ale\\AppData\\Local\\udsw\\cursor\\u\\ale-win-test-1";
+    assert.ok(
+      commandLineUsesUserdataRoot(
+        `4321 "C:\\Program Files\\Cursor\\Cursor.exe" --user-data-dir="${userdataRoot}"`,
+        userdataRoot,
+      ),
+    );
+    assert.ok(
+      commandLineUsesUserdataRoot(
+        `4321 "C:\\Program Files\\Cursor\\Cursor.exe" --user-data-dir="${userdataRoot.toUpperCase()}"`,
+        userdataRoot,
+      ),
     );
   });
 });
@@ -128,5 +146,64 @@ describe("quitUserdataEditorInstance", () => {
       { pid: 4321, signal: "SIGTERM" },
       { pid: 4321, signal: "SIGKILL" },
     ]);
+  });
+});
+
+describe("isUserdataEditorInstanceRunning", () => {
+  it("detects a running Windows editor process by command line", async () => {
+    const userdataRoot =
+      "C:\\Users\\ale\\AppData\\Local\\udsw\\cursor\\u\\ale-win-test-1";
+    const running = await isUserdataEditorInstanceRunning(userdataRoot, {
+      platform: "win32",
+      listProcessLines: () => [
+        `4321 "C:\\Program Files\\Cursor\\Cursor.exe" --user-data-dir="${userdataRoot}"`,
+      ],
+    });
+
+    assert.equal(running, true);
+  });
+
+  it("reports not running on Windows when no process matches the userdata root", async () => {
+    const running = await isUserdataEditorInstanceRunning(
+      "C:\\Users\\ale\\AppData\\Local\\udsw\\cursor\\u\\ale-win-test-1",
+      {
+        platform: "win32",
+        listProcessLines: () => [
+          '4321 "C:\\Program Files\\Cursor\\Cursor.exe" --user-data-dir="C:\\Users\\ale\\AppData\\Local\\udsw\\cursor\\u\\other"',
+        ],
+      },
+    );
+
+    assert.equal(running, false);
+  });
+});
+
+describe("quitUserdataEditorInstance on Windows", () => {
+  it("terminates matching processes via taskkill and waits until they are gone", async () => {
+    const userdataRoot =
+      "C:\\Users\\ale\\AppData\\Local\\udsw\\cursor\\u\\ale-win-test-1";
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let running = true;
+
+    const quit = await quitUserdataEditorInstance(userdataRoot, {
+      platform: "win32",
+      listProcessLines: () =>
+        running
+          ? [
+              `4321 "C:\\Program Files\\Cursor\\Cursor.exe" --user-data-dir="${userdataRoot}"`,
+            ]
+          : [],
+      killProcess: (pid, signal) => {
+        killed.push({ pid, signal });
+        if (signal === "SIGTERM") {
+          running = false;
+        }
+      },
+      sleep: async () => {},
+      waitTimeoutMs: 1_000,
+    });
+
+    assert.equal(quit, true);
+    assert.deepEqual(killed, [{ pid: 4321, signal: "SIGTERM" }]);
   });
 });

--- a/src/runningEditorInstance.ts
+++ b/src/runningEditorInstance.ts
@@ -4,6 +4,7 @@ import {
   probeRunningUserdataInstance,
   type RunningInstanceProbeDeps,
 } from "./editorIpc";
+import { pathApiForPath } from "./paths";
 
 const HELPER_PROCESS_MARKERS = [
   " Helper",
@@ -22,13 +23,22 @@ export function commandLineUsesUserdataRoot(
   command: string,
   userdataRoot: string,
 ): boolean {
-  const resolvedRoot = path.resolve(userdataRoot);
   for (const candidate of parseUserDataDirArgs(command)) {
-    if (path.resolve(candidate) === resolvedRoot) {
+    if (userdataRootsEqual(candidate, userdataRoot)) {
       return true;
     }
   }
   return false;
+}
+
+function userdataRootsEqual(left: string, right: string): boolean {
+  const pathApi =
+    pathApiForPath(left) === path.win32 ? path.win32 : pathApiForPath(right);
+  const normalizedLeft = pathApi.resolve(left);
+  const normalizedRight = pathApi.resolve(right);
+  return pathApi === path.win32
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
 }
 
 function parseUserDataDirArgs(command: string): string[] {
@@ -52,7 +62,11 @@ function parseUserDataDirArgs(command: string): string[] {
 
     if (rawValue !== undefined) {
       const nextFlag = rawValue.indexOf(" --");
-      values.push(nextFlag === -1 ? rawValue : rawValue.slice(0, nextFlag));
+      values.push(
+        normalizeArgValue(
+          nextFlag === -1 ? rawValue : rawValue.slice(0, nextFlag),
+        ),
+      );
     }
 
     searchFrom = flagIndex + flag.length;
@@ -61,15 +75,27 @@ function parseUserDataDirArgs(command: string): string[] {
   return values;
 }
 
+function normalizeArgValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
 export function isMainEditorProcess(command: string): boolean {
   return !HELPER_PROCESS_MARKERS.some((marker) => command.includes(marker));
 }
 
 export function listMainProcessIdsForUserdataRoot(
   userdataRoot: string,
-  deps: Pick<QuitUserdataInstanceDeps, "listProcessLines"> = {},
+  deps: Pick<QuitUserdataInstanceDeps, "listProcessLines" | "platform"> = {},
 ): number[] {
-  const lines = deps.listProcessLines ?? defaultProcessLines;
+  const platform = deps.platform ?? process.platform;
+  const lines = deps.listProcessLines ?? createDefaultProcessLines(platform);
   const processIds = new Set<number>();
 
   for (const line of lines()) {
@@ -89,17 +115,24 @@ export function listMainProcessIdsForUserdataRoot(
   return [...processIds];
 }
 
-export async function quitUserdataEditorInstance(
+export async function isUserdataEditorInstanceRunning(
   userdataRoot: string,
   deps: QuitUserdataInstanceDeps = {},
 ): Promise<boolean> {
   const platform = deps.platform ?? process.platform;
   if (platform === "win32") {
-    return false;
+    return listMainProcessIdsForUserdataRoot(userdataRoot, deps).length > 0;
   }
 
-  const killProcess =
-    deps.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+  return (await probeRunningUserdataInstance(userdataRoot, deps)) === "running";
+}
+
+export async function quitUserdataEditorInstance(
+  userdataRoot: string,
+  deps: QuitUserdataInstanceDeps = {},
+): Promise<boolean> {
+  const platform = deps.platform ?? process.platform;
+  const killProcess = deps.killProcess ?? createDefaultKillProcess(platform);
   const sleep =
     deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   const waitTimeoutMs = deps.waitTimeoutMs ?? 5_000;
@@ -107,10 +140,7 @@ export async function quitUserdataEditorInstance(
   const waitUntilStopped = async (deadlineMs: number): Promise<boolean> => {
     const deadline = Date.now() + deadlineMs;
     while (Date.now() < deadline) {
-      if (
-        (await probeRunningUserdataInstance(userdataRoot, deps)) ===
-        "not-running"
-      ) {
+      if (!(await isUserdataEditorInstanceRunning(userdataRoot, deps))) {
         return true;
       }
       await sleep(200);
@@ -137,10 +167,50 @@ export async function quitUserdataEditorInstance(
   return waitUntilStopped(2_000);
 }
 
-function defaultProcessLines(): string[] {
+function createDefaultProcessLines(platform: NodeJS.Platform): () => string[] {
+  return platform === "win32"
+    ? defaultWindowsProcessLines
+    : defaultUnixProcessLines;
+}
+
+function createDefaultKillProcess(
+  platform: NodeJS.Platform,
+): (pid: number, signal: NodeJS.Signals) => void {
+  if (platform === "win32") {
+    return (pid, signal) => {
+      const args =
+        signal === "SIGKILL"
+          ? ["/F", "/PID", String(pid)]
+          : ["/PID", String(pid)];
+      spawnSync("taskkill", args, { stdio: "ignore" });
+    };
+  }
+
+  return (pid, signal) => {
+    process.kill(pid, signal);
+  };
+}
+
+function defaultUnixProcessLines(): string[] {
   const result = spawnSync("ps", ["ax", "-o", "pid=", "-o", "command="], {
     encoding: "utf8",
   });
+  if (result.status !== 0) {
+    return [];
+  }
+  return result.stdout.split(/\r?\n/).filter(Boolean);
+}
+
+function defaultWindowsProcessLines(): string[] {
+  const result = spawnSync(
+    "powershell",
+    [
+      "-NoProfile",
+      "-Command",
+      'Get-CimInstance Win32_Process | Where-Object { $_.CommandLine } | ForEach-Object { "$($_.ProcessId) $($_.CommandLine)" }',
+    ],
+    { encoding: "utf8", timeout: 10_000 },
+  );
   if (result.status !== 0) {
     return [];
   }

--- a/src/runningEditorInstance.ts
+++ b/src/runningEditorInstance.ts
@@ -23,14 +23,42 @@ export function commandLineUsesUserdataRoot(
   userdataRoot: string,
 ): boolean {
   const resolvedRoot = path.resolve(userdataRoot);
-  return (
-    command.includes(resolvedRoot) ||
-    command.includes(userdataRoot) ||
-    command.includes(`--user-data-dir=${resolvedRoot}`) ||
-    command.includes(`--user-data-dir=${userdataRoot}`) ||
-    command.includes(`--user-data-dir ${resolvedRoot}`) ||
-    command.includes(`--user-data-dir ${userdataRoot}`)
-  );
+  for (const candidate of parseUserDataDirArgs(command)) {
+    if (path.resolve(candidate) === resolvedRoot) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parseUserDataDirArgs(command: string): string[] {
+  const flag = "--user-data-dir";
+  const values: string[] = [];
+  let searchFrom = 0;
+
+  while (searchFrom < command.length) {
+    const flagIndex = command.indexOf(flag, searchFrom);
+    if (flagIndex === -1) {
+      break;
+    }
+
+    const afterFlag = command.slice(flagIndex + flag.length);
+    let rawValue: string | undefined;
+    if (afterFlag.startsWith("=")) {
+      rawValue = afterFlag.slice(1);
+    } else if (/^\s/.test(afterFlag)) {
+      rawValue = afterFlag.trimStart();
+    }
+
+    if (rawValue !== undefined) {
+      const nextFlag = rawValue.indexOf(" --");
+      values.push(nextFlag === -1 ? rawValue : rawValue.slice(0, nextFlag));
+    }
+
+    searchFrom = flagIndex + flag.length;
+  }
+
+  return values;
 }
 
 export function isMainEditorProcess(command: string): boolean {

--- a/src/runningEditorInstance.ts
+++ b/src/runningEditorInstance.ts
@@ -1,0 +1,120 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import {
+  probeRunningUserdataInstance,
+  type RunningInstanceProbeDeps,
+} from "./editorIpc";
+
+const HELPER_PROCESS_MARKERS = [
+  " Helper",
+  "crashpad_handler",
+  "chrome_crashpad",
+];
+
+export interface QuitUserdataInstanceDeps extends RunningInstanceProbeDeps {
+  listProcessLines?: () => string[];
+  killProcess?: (pid: number, signal: NodeJS.Signals) => void;
+  sleep?: (ms: number) => Promise<void>;
+  waitTimeoutMs?: number;
+}
+
+export function commandLineUsesUserdataRoot(
+  command: string,
+  userdataRoot: string,
+): boolean {
+  const resolvedRoot = path.resolve(userdataRoot);
+  return (
+    command.includes(resolvedRoot) ||
+    command.includes(userdataRoot) ||
+    command.includes(`--user-data-dir=${resolvedRoot}`) ||
+    command.includes(`--user-data-dir=${userdataRoot}`) ||
+    command.includes(`--user-data-dir ${resolvedRoot}`) ||
+    command.includes(`--user-data-dir ${userdataRoot}`)
+  );
+}
+
+export function isMainEditorProcess(command: string): boolean {
+  return !HELPER_PROCESS_MARKERS.some((marker) => command.includes(marker));
+}
+
+export function listMainProcessIdsForUserdataRoot(
+  userdataRoot: string,
+  deps: Pick<QuitUserdataInstanceDeps, "listProcessLines"> = {},
+): number[] {
+  const lines = deps.listProcessLines ?? defaultProcessLines;
+  const processIds = new Set<number>();
+
+  for (const line of lines()) {
+    if (
+      !commandLineUsesUserdataRoot(line, userdataRoot) ||
+      !isMainEditorProcess(line)
+    ) {
+      continue;
+    }
+
+    const match = line.trim().match(/^(\d+)\s+/);
+    if (match) {
+      processIds.add(Number(match[1]));
+    }
+  }
+
+  return [...processIds];
+}
+
+export async function quitUserdataEditorInstance(
+  userdataRoot: string,
+  deps: QuitUserdataInstanceDeps = {},
+): Promise<boolean> {
+  const platform = deps.platform ?? process.platform;
+  if (platform === "win32") {
+    return false;
+  }
+
+  const killProcess =
+    deps.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+  const sleep =
+    deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const waitTimeoutMs = deps.waitTimeoutMs ?? 5_000;
+
+  const waitUntilStopped = async (deadlineMs: number): Promise<boolean> => {
+    const deadline = Date.now() + deadlineMs;
+    while (Date.now() < deadline) {
+      if (
+        (await probeRunningUserdataInstance(userdataRoot, deps)) ===
+        "not-running"
+      ) {
+        return true;
+      }
+      await sleep(200);
+    }
+    return false;
+  };
+
+  const signalMatchingProcesses = (signal: NodeJS.Signals) => {
+    for (const pid of listMainProcessIdsForUserdataRoot(userdataRoot, deps)) {
+      try {
+        killProcess(pid, signal);
+      } catch {
+        // Another caller may already have stopped the process.
+      }
+    }
+  };
+
+  signalMatchingProcesses("SIGTERM");
+  if (await waitUntilStopped(waitTimeoutMs)) {
+    return true;
+  }
+
+  signalMatchingProcesses("SIGKILL");
+  return waitUntilStopped(2_000);
+}
+
+function defaultProcessLines(): string[] {
+  const result = spawnSync("ps", ["ax", "-o", "pid=", "-o", "command="], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    return [];
+  }
+  return result.stdout.split(/\r?\n/).filter(Boolean);
+}

--- a/src/userdataSwitcherApp.ts
+++ b/src/userdataSwitcherApp.ts
@@ -354,7 +354,7 @@ export function activateUserdataSwitcher(
 
     const items: QuickPickItem[] = deletable.map((entry) => ({
       label: formatUserdataLabel({ kind: "known", entry }),
-      description: entry.relativeDataDir ? `u/${entry.id}` : undefined,
+      description: entry.relativeDataDir,
       intent: { kind: "open", userdataId: entry.id },
     }));
 
@@ -409,6 +409,7 @@ export function activateUserdataSwitcher(
         return choice === confirmLabel;
       },
       logInfo: (message) => logger?.info(message),
+      logError: (message) => logger?.error(message),
     });
 
     switch (outcome.status) {

--- a/src/userdataSwitcherApp.ts
+++ b/src/userdataSwitcherApp.ts
@@ -1,13 +1,16 @@
 import fs from "node:fs";
+import { executeManagedUserdataDeletion } from "./deleteManagedUserdata";
 import {
-  DELETE_IN_USE_MESSAGE,
+  DELETE_QUIT_FAILED_MESSAGE,
   DELETE_TRASH_FAILURE_MESSAGE,
+  DELETE_VERIFY_INSTANCE_STILL_RUNNING_MESSAGE,
+  DELETE_VERIFY_PATH_STILL_EXISTS_MESSAGE,
   describeDeleteUserdataBlockedReason,
   listDeletableManagedUserdatas,
 } from "./deleteUserdata";
 import type { CurrentUserdata } from "./detect";
 import { EditorHostSession } from "./editorHostSession";
-import { listMainSocketPaths, probeRunningUserdataInstance } from "./editorIpc";
+import { probeRunningUserdataInstance } from "./editorIpc";
 import type { SupportedHostAdapter } from "./host";
 import {
   formatOpenWithUserdataPickerTitle,
@@ -35,6 +38,7 @@ import {
   type UserdataEntry,
 } from "./registry";
 import { UserdataRegistryStore } from "./registryStore";
+import { quitUserdataEditorInstance } from "./runningEditorInstance";
 
 export const COMMAND_OPEN_WITH_USERDATA = "userdataSwitcher.openWithUserdata";
 export const COMMAND_CREATE_USERDATA = "userdataSwitcher.createUserdata";
@@ -107,6 +111,9 @@ export interface UserdataSwitcherActivation {
   mkdirSync?: typeof fs.mkdirSync;
   editorVersion?: string;
   isManagedUserdataInUse?: (managedUserdataRoot: string) => Promise<boolean>;
+  quitManagedUserdataInstance?: (
+    managedUserdataRoot: string,
+  ) => Promise<boolean>;
 }
 
 type UserdataCreationMode = "seedCurrent" | "empty";
@@ -162,6 +169,8 @@ export function activateUserdataSwitcher(
       (await probeRunningUserdataInstance(managedUserdataRoot, {
         editorVersion,
       })) === "running",
+    quitManagedUserdataInstance = async (managedUserdataRoot) =>
+      quitUserdataEditorInstance(managedUserdataRoot, { editorVersion }),
   } = input;
 
   const storeRoot = host.resolveStoreRoot();
@@ -365,17 +374,6 @@ export function activateUserdataSwitcher(
       return;
     }
 
-    const confirm = await ui.showWarningMessage(
-      `Are you sure you want to delete userdata "${targetEntry.label}"? Close all windows using it first. This will move its settings and data files to the trash.`,
-      "Delete",
-      "Cancel",
-    );
-
-    if (confirm !== "Delete") {
-      logger?.info("Delete userdata cancelled by user confirmation");
-      return;
-    }
-
     let targetPath: string;
     try {
       targetPath = resolveManagedDataDir(
@@ -389,37 +387,68 @@ export function activateUserdataSwitcher(
       return;
     }
 
-    const socketCandidates = listMainSocketPaths(targetPath, editorVersion);
-    logger?.info(
-      `Delete preflight socket candidates: ${
-        socketCandidates.length > 0 ? socketCandidates.join(", ") : "(none)"
-      }`,
-    );
+    const outcome = await executeManagedUserdataDeletion({
+      targetPath,
+      label: targetEntry.label,
+      editorVersion,
+      isManagedUserdataInUse,
+      quitManagedUserdataInstance,
+      deletePath: async (managedUserdataRoot) => {
+        logger?.info(
+          `deletePath fsPath="${managedUserdataRoot}" useTrash=true`,
+        );
+        await ui.deletePath(managedUserdataRoot, { useTrash: true });
+      },
+      pathExists: (managedUserdataRoot) => fs.existsSync(managedUserdataRoot),
+      confirmDeletion: async (message, confirmLabel) => {
+        const choice = await ui.showWarningMessage(
+          message,
+          confirmLabel,
+          "Cancel",
+        );
+        return choice === confirmLabel;
+      },
+      logInfo: (message) => logger?.info(message),
+    });
 
-    if (await isManagedUserdataInUse(targetPath)) {
-      logger?.info(
-        `Delete userdata blocked: ${targetEntry.id} still has a running editor instance`,
-      );
-      await ui.showWarningMessage(DELETE_IN_USE_MESSAGE);
-      return;
-    }
-
-    try {
-      await ui.deletePath(targetPath, { useTrash: true });
-      const updatedRegistry = registryStore.update((latest) =>
-        removeUserdata(latest, targetEntry.id),
-      );
-      refreshStatusBar(updatedRegistry);
-      logger?.info(
-        `Deleted userdata ${targetEntry.id} and moved files to trash`,
-      );
-      await ui.showInformationMessage(
-        `Userdata "${targetEntry.label}" has been deleted.`,
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger?.error(`Delete userdata files failed: ${message}`);
-      await ui.showWarningMessage(DELETE_TRASH_FAILURE_MESSAGE);
+    switch (outcome.status) {
+      case "cancelled":
+        logger?.info("Delete userdata cancelled by user confirmation");
+        return;
+      case "quit-failed":
+        logger?.info(
+          `Delete userdata blocked: ${targetEntry.id} editor instance could not be quit`,
+        );
+        await ui.showWarningMessage(DELETE_QUIT_FAILED_MESSAGE);
+        return;
+      case "delete-failed": {
+        logger?.error(`Delete userdata files failed for ${targetEntry.id}`);
+        await ui.showWarningMessage(DELETE_TRASH_FAILURE_MESSAGE);
+        return;
+      }
+      case "verify-failed":
+        logger?.error(
+          `Delete userdata verification failed for ${targetEntry.id}: ${outcome.reason}`,
+        );
+        await ui.showWarningMessage(
+          outcome.reason === "path-still-exists"
+            ? DELETE_VERIFY_PATH_STILL_EXISTS_MESSAGE
+            : DELETE_VERIFY_INSTANCE_STILL_RUNNING_MESSAGE,
+        );
+        return;
+      case "success": {
+        const updatedRegistry = registryStore.update((latest) =>
+          removeUserdata(latest, targetEntry.id),
+        );
+        refreshStatusBar(updatedRegistry);
+        logger?.info(
+          `Deleted userdata ${targetEntry.id} and moved files to trash`,
+        );
+        await ui.showInformationMessage(
+          `Userdata "${targetEntry.label}" has been deleted.`,
+        );
+        return;
+      }
     }
   };
 

--- a/src/userdataSwitcherApp.ts
+++ b/src/userdataSwitcherApp.ts
@@ -57,7 +57,6 @@ export interface QuickPickItem {
   description?: string;
   kind?: number;
   intent?: UserdataMenuItemIntent;
-  creationMode?: UserdataCreationMode;
   alwaysShow?: boolean;
 }
 
@@ -96,7 +95,10 @@ export interface UserdataSwitcherUi {
     message: string,
     ...items: string[]
   ): PromiseLike<string | undefined>;
-  showInformationMessage(message: string): PromiseLike<unknown>;
+  showInformationMessage(
+    message: string,
+    ...items: string[]
+  ): PromiseLike<string | undefined>;
   revealPathInOs(fsPath: string): PromiseLike<unknown>;
   deletePath(fsPath: string, options: { useTrash: boolean }): PromiseLike<void>;
 }
@@ -122,19 +124,6 @@ type UserdataCreationMode = "seedCurrent" | "empty";
 
 const CREATE_FROM_CURRENT_SETTINGS_LABEL = "Start from current settings";
 const CREATE_EMPTY_LABEL = "Start empty";
-
-const USERDATA_CREATION_MODE_ITEMS: readonly QuickPickItem[] = [
-  {
-    label: CREATE_FROM_CURRENT_SETTINGS_LABEL,
-    description: "Recommended",
-    creationMode: "seedCurrent",
-  },
-  {
-    label: CREATE_EMPTY_LABEL,
-    description: "Fresh editor defaults",
-    creationMode: "empty",
-  },
-];
 
 function requireNonEmptyLabel(value: string): string | undefined {
   return value.trim() ? undefined : "Label is required";
@@ -260,26 +249,24 @@ export function activateUserdataSwitcher(
     }
   };
 
-  const pickUserdataCreationMode = async (): Promise<
-    UserdataCreationMode | undefined
-  > => {
-    const selected = await ui.showQuickPick(USERDATA_CREATION_MODE_ITEMS, {
-      title: "Create Userdata",
-      placeHolder: "Choose how to initialize the new userdata",
-    });
-    return selected?.creationMode;
+  const pickUserdataCreationMode = async (
+    label: string,
+  ): Promise<UserdataCreationMode | undefined> => {
+    const choice = await ui.showInformationMessage(
+      `How should "${label}" be initialized?`,
+      CREATE_FROM_CURRENT_SETTINGS_LABEL,
+      CREATE_EMPTY_LABEL,
+    );
+    if (choice === CREATE_FROM_CURRENT_SETTINGS_LABEL) {
+      return "seedCurrent";
+    }
+    if (choice === CREATE_EMPTY_LABEL) {
+      return "empty";
+    }
+    return undefined;
   };
 
   const createUserdata = async () => {
-    const creationMode = await pickUserdataCreationMode();
-    if (!creationMode) {
-      logger?.info("Create userdata cancelled");
-      return;
-    }
-    const sourceUserdataRoot =
-      creationMode === "seedCurrent"
-        ? (session.currentUserdataRoot(currentUserdata()) ?? undefined)
-        : undefined;
     const label = await ui.showInputBox({
       title: "Create Userdata",
       prompt: `Enter a label for the new ${host.displayName} Userdata`,
@@ -290,6 +277,15 @@ export function activateUserdataSwitcher(
       logger?.info("Create userdata cancelled");
       return;
     }
+    const creationMode = await pickUserdataCreationMode(label);
+    if (!creationMode) {
+      logger?.info("Create userdata cancelled");
+      return;
+    }
+    const sourceUserdataRoot =
+      creationMode === "seedCurrent"
+        ? (session.currentUserdataRoot(currentUserdata()) ?? undefined)
+        : undefined;
     try {
       if (creationMode === "seedCurrent" && !sourceUserdataRoot) {
         throw new Error(

--- a/src/userdataSwitcherApp.ts
+++ b/src/userdataSwitcherApp.ts
@@ -7,7 +7,7 @@ import {
 } from "./deleteUserdata";
 import type { CurrentUserdata } from "./detect";
 import { EditorHostSession } from "./editorHostSession";
-import { probeRunningUserdataInstance } from "./editorIpc";
+import { listMainSocketPaths, probeRunningUserdataInstance } from "./editorIpc";
 import type { SupportedHostAdapter } from "./host";
 import {
   formatOpenWithUserdataPickerTitle,
@@ -105,6 +105,7 @@ export interface UserdataSwitcherActivation {
   logger?: LaunchLogger;
   launchEditorImpl?: LaunchEditor;
   mkdirSync?: typeof fs.mkdirSync;
+  editorVersion?: string;
   isManagedUserdataInUse?: (managedUserdataRoot: string) => Promise<boolean>;
 }
 
@@ -156,8 +157,11 @@ export function activateUserdataSwitcher(
     logger,
     launchEditorImpl,
     mkdirSync,
+    editorVersion,
     isManagedUserdataInUse = async (managedUserdataRoot) =>
-      (await probeRunningUserdataInstance(managedUserdataRoot)) === "running",
+      (await probeRunningUserdataInstance(managedUserdataRoot, {
+        editorVersion,
+      })) === "running",
   } = input;
 
   const storeRoot = host.resolveStoreRoot();
@@ -234,6 +238,7 @@ export function activateUserdataSwitcher(
         appRoot,
         storeRoot,
         workspace,
+        editorVersion,
         logger,
         launchEditorImpl,
       });
@@ -383,6 +388,13 @@ export function activateUserdataSwitcher(
       await ui.showErrorMessage(message);
       return;
     }
+
+    const socketCandidates = listMainSocketPaths(targetPath, editorVersion);
+    logger?.info(
+      `Delete preflight socket candidates: ${
+        socketCandidates.length > 0 ? socketCandidates.join(", ") : "(none)"
+      }`,
+    );
 
     if (await isManagedUserdataInUse(targetPath)) {
       logger?.info(

--- a/src/userdataSwitcherApp.ts
+++ b/src/userdataSwitcherApp.ts
@@ -1,6 +1,13 @@
 import fs from "node:fs";
+import {
+  DELETE_IN_USE_MESSAGE,
+  DELETE_TRASH_FAILURE_MESSAGE,
+  describeDeleteUserdataBlockedReason,
+  listDeletableManagedUserdatas,
+} from "./deleteUserdata";
 import type { CurrentUserdata } from "./detect";
 import { EditorHostSession } from "./editorHostSession";
+import { probeRunningUserdataInstance } from "./editorIpc";
 import type { SupportedHostAdapter } from "./host";
 import {
   formatOpenWithUserdataPickerTitle,
@@ -98,6 +105,7 @@ export interface UserdataSwitcherActivation {
   logger?: LaunchLogger;
   launchEditorImpl?: LaunchEditor;
   mkdirSync?: typeof fs.mkdirSync;
+  isManagedUserdataInUse?: (managedUserdataRoot: string) => Promise<boolean>;
 }
 
 type UserdataCreationMode = "seedCurrent" | "empty";
@@ -148,6 +156,8 @@ export function activateUserdataSwitcher(
     logger,
     launchEditorImpl,
     mkdirSync,
+    isManagedUserdataInUse = async (managedUserdataRoot) =>
+      (await probeRunningUserdataInstance(managedUserdataRoot)) === "running",
   } = input;
 
   const storeRoot = host.resolveStoreRoot();
@@ -317,16 +327,14 @@ export function activateUserdataSwitcher(
   const deleteUserdata = async () => {
     const currentRegistry = registryStore.read();
     const current = currentUserdata(currentRegistry);
-    const deletable = currentRegistry.userdatas.filter(
-      (entry) =>
-        entry.kind === "managed" &&
-        (current.kind === "unmanaged" || entry.id !== current.entry.id),
+    const deletable = listDeletableManagedUserdatas(currentRegistry, current);
+    const blockedReason = describeDeleteUserdataBlockedReason(
+      currentRegistry,
+      current,
     );
 
-    if (deletable.length === 0) {
-      await ui.showWarningMessage(
-        "No other managed userdatas available to delete.",
-      );
+    if (blockedReason) {
+      await ui.showWarningMessage(blockedReason);
       return;
     }
 
@@ -353,7 +361,7 @@ export function activateUserdataSwitcher(
     }
 
     const confirm = await ui.showWarningMessage(
-      `Are you sure you want to delete userdata "${targetEntry.label}"? This will move all its settings and data files to the trash.`,
+      `Are you sure you want to delete userdata "${targetEntry.label}"? Close all windows using it first. This will move its settings and data files to the trash.`,
       "Delete",
       "Cancel",
     );
@@ -376,6 +384,14 @@ export function activateUserdataSwitcher(
       return;
     }
 
+    if (await isManagedUserdataInUse(targetPath)) {
+      logger?.info(
+        `Delete userdata blocked: ${targetEntry.id} still has a running editor instance`,
+      );
+      await ui.showWarningMessage(DELETE_IN_USE_MESSAGE);
+      return;
+    }
+
     try {
       await ui.deletePath(targetPath, { useTrash: true });
       const updatedRegistry = registryStore.update((latest) =>
@@ -391,9 +407,7 @@ export function activateUserdataSwitcher(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger?.error(`Delete userdata files failed: ${message}`);
-      await ui.showWarningMessage(
-        `Could not delete userdata folder. It might be open in another window. Please close all windows using this userdata and try again.`,
-      );
+      await ui.showWarningMessage(DELETE_TRASH_FAILURE_MESSAGE);
     }
   };
 
@@ -403,6 +417,7 @@ export function activateUserdataSwitcher(
     logger?.info(
       `Opening menu from current userdata: ${formatUserdataLabel(current)}`,
     );
+    refreshStatusBar(currentRegistry);
     const items = toQuickPickItems(
       buildOpenWithUserdataMenuItems(currentRegistry, current),
       ui.QuickPickItemKind.Separator,

--- a/src/userdataSwitcherApp.ts
+++ b/src/userdataSwitcherApp.ts
@@ -10,7 +10,6 @@ import {
 } from "./deleteUserdata";
 import type { CurrentUserdata } from "./detect";
 import { EditorHostSession } from "./editorHostSession";
-import { probeRunningUserdataInstance } from "./editorIpc";
 import type { SupportedHostAdapter } from "./host";
 import {
   formatOpenWithUserdataPickerTitle,
@@ -38,7 +37,10 @@ import {
   type UserdataEntry,
 } from "./registry";
 import { UserdataRegistryStore } from "./registryStore";
-import { quitUserdataEditorInstance } from "./runningEditorInstance";
+import {
+  isUserdataEditorInstanceRunning,
+  quitUserdataEditorInstance,
+} from "./runningEditorInstance";
 
 export const COMMAND_OPEN_WITH_USERDATA = "userdataSwitcher.openWithUserdata";
 export const COMMAND_CREATE_USERDATA = "userdataSwitcher.createUserdata";
@@ -166,9 +168,9 @@ export function activateUserdataSwitcher(
     mkdirSync,
     editorVersion,
     isManagedUserdataInUse = async (managedUserdataRoot) =>
-      (await probeRunningUserdataInstance(managedUserdataRoot, {
+      isUserdataEditorInstanceRunning(managedUserdataRoot, {
         editorVersion,
-      })) === "running",
+      }),
     quitManagedUserdataInstance = async (managedUserdataRoot) =>
       quitUserdataEditorInstance(managedUserdataRoot, { editorVersion }),
   } = input;
@@ -394,9 +396,6 @@ export function activateUserdataSwitcher(
       isManagedUserdataInUse,
       quitManagedUserdataInstance,
       deletePath: async (managedUserdataRoot) => {
-        logger?.info(
-          `deletePath fsPath="${managedUserdataRoot}" useTrash=true`,
-        );
         await ui.deletePath(managedUserdataRoot, { useTrash: true });
       },
       pathExists: (managedUserdataRoot) => fs.existsSync(managedUserdataRoot),

--- a/src/userdataSwitcherApp.ts
+++ b/src/userdataSwitcherApp.ts
@@ -20,8 +20,13 @@ import {
   type UserdataMenuItem,
   type UserdataMenuItemIntent,
 } from "./menu";
-import { registryPath } from "./paths";
-import { type Registry, renameUserdata, type UserdataEntry } from "./registry";
+import { registryPath, resolveManagedDataDir } from "./paths";
+import {
+  type Registry,
+  removeUserdata,
+  renameUserdata,
+  type UserdataEntry,
+} from "./registry";
 import { UserdataRegistryStore } from "./registryStore";
 
 export const COMMAND_OPEN_WITH_USERDATA = "userdataSwitcher.openWithUserdata";
@@ -32,6 +37,7 @@ export const COMMAND_SHOW_CURRENT_USERDATA =
   "userdataSwitcher.showCurrentUserdata";
 export const COMMAND_REVEAL_CURRENT_USERDATA =
   "userdataSwitcher.revealCurrentUserdata";
+export const COMMAND_DELETE_USERDATA = "userdataSwitcher.deleteUserdata";
 
 export interface QuickPickItem {
   label: string;
@@ -73,9 +79,13 @@ export interface UserdataSwitcherUi {
     validateInput?(value: string): string | undefined;
   }): PromiseLike<string | undefined>;
   showErrorMessage(message: string): PromiseLike<unknown>;
-  showWarningMessage(message: string): PromiseLike<unknown>;
+  showWarningMessage(
+    message: string,
+    ...items: string[]
+  ): PromiseLike<string | undefined>;
   showInformationMessage(message: string): PromiseLike<unknown>;
   revealPathInOs(fsPath: string): PromiseLike<unknown>;
+  deletePath(fsPath: string, options: { useTrash: boolean }): PromiseLike<void>;
 }
 
 export interface UserdataSwitcherActivation {
@@ -304,6 +314,89 @@ export function activateUserdataSwitcher(
     logger?.info(`Renamed userdata ${current.entry.id} to ${label}`);
   };
 
+  const deleteUserdata = async () => {
+    const currentRegistry = registryStore.read();
+    const current = currentUserdata(currentRegistry);
+    const deletable = currentRegistry.userdatas.filter(
+      (entry) =>
+        entry.kind === "managed" &&
+        (current.kind === "unmanaged" || entry.id !== current.entry.id),
+    );
+
+    if (deletable.length === 0) {
+      await ui.showWarningMessage(
+        "No other managed userdatas available to delete.",
+      );
+      return;
+    }
+
+    const items: QuickPickItem[] = deletable.map((entry) => ({
+      label: formatUserdataLabel({ kind: "known", entry }),
+      description: entry.relativeDataDir ? `u/${entry.id}` : undefined,
+      intent: { kind: "open", userdataId: entry.id },
+    }));
+
+    const selected = await ui.showQuickPick(items, {
+      title: "Delete Userdata",
+      placeHolder: "Select a userdata to delete",
+    });
+
+    if (selected?.intent?.kind !== "open") {
+      logger?.info("Delete userdata cancelled");
+      return;
+    }
+
+    const targetId = selected.intent.userdataId;
+    const targetEntry = deletable.find((entry) => entry.id === targetId);
+    if (!targetEntry?.relativeDataDir) {
+      return;
+    }
+
+    const confirm = await ui.showWarningMessage(
+      `Are you sure you want to delete userdata "${targetEntry.label}"? This will move all its settings and data files to the trash.`,
+      "Delete",
+      "Cancel",
+    );
+
+    if (confirm !== "Delete") {
+      logger?.info("Delete userdata cancelled by user confirmation");
+      return;
+    }
+
+    let targetPath: string;
+    try {
+      targetPath = resolveManagedDataDir(
+        storeRoot,
+        targetEntry.relativeDataDir,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger?.error(`Resolve path failed: ${message}`);
+      await ui.showErrorMessage(message);
+      return;
+    }
+
+    try {
+      await ui.deletePath(targetPath, { useTrash: true });
+      const updatedRegistry = registryStore.update((latest) =>
+        removeUserdata(latest, targetEntry.id),
+      );
+      refreshStatusBar(updatedRegistry);
+      logger?.info(
+        `Deleted userdata ${targetEntry.id} and moved files to trash`,
+      );
+      await ui.showInformationMessage(
+        `Userdata "${targetEntry.label}" has been deleted.`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger?.error(`Delete userdata files failed: ${message}`);
+      await ui.showWarningMessage(
+        `Could not delete userdata folder. It might be open in another window. Please close all windows using this userdata and try again.`,
+      );
+    }
+  };
+
   const openWithUserdataMenu = async () => {
     const currentRegistry = registryStore.read();
     const current = currentUserdata(currentRegistry);
@@ -336,6 +429,10 @@ export function activateUserdataSwitcher(
         logger?.info("Menu intent: reveal current userdata");
         await revealCurrentUserdata();
         return;
+      case "delete":
+        logger?.info("Menu intent: delete userdata");
+        await deleteUserdata();
+        return;
       case "open":
         logger?.info(`Menu intent: open userdata ${intent.entry.id}`);
         await launchEntrySafely(intent.entry);
@@ -361,6 +458,7 @@ export function activateUserdataSwitcher(
   subscribe(
     ui.registerCommand(COMMAND_REVEAL_CURRENT_USERDATA, revealCurrentUserdata),
   );
+  subscribe(ui.registerCommand(COMMAND_DELETE_USERDATA, deleteUserdata));
 
   refreshStatusBar();
 }


### PR DESCRIPTION
## Summary

Follow-up PR that rebases and hardens [@tazztone](https://github.com/tazztone)'s deletion work from #11 onto `main` (v1.2.0).

- **Contributor base:** managed userdata deletion via menu/command, trash + registry removal, managed-only + exclude-current guards (from #11).
- **Maintainer hardening:** IPC-socket preflight on macOS/Linux to block deletes while a userdata instance is still running; quit-and-delete flow; post-delete verification; clearer blocked-delete messaging; status bar refresh on menu open; create-flow UX fix; docs/tests.

Supersedes #11.

## Credits

Thanks to [@tazztone](https://github.com/tazztone) for the original managed userdata deletion implementation in #11. This PR incorporates that work and extends it with running-instance preflight, quit-and-delete, verification, Windows support, and additional safety/UX polish.

## Why the preflight

On macOS/Linux, moving a userdata directory to Trash can succeed even while editor windows still hold it open. The original try-and-fail approach mostly protects on Windows only. We now connect to the editor IPC socket under the target userdata root and block before trashing when the instance is still running.

## Test plan

- [x] `npm run check`
- [x] `npm test` (163 tests)
- [x] Manual: create Work + Personal, open Personal in another window, delete Personal from Work → blocked with in-use message
- [x] Manual: close Personal windows, delete from Work → trash + registry removal
- [x] Manual: try deleting from Personal window when it is the only managed userdata → current-window message